### PR TITLE
🦋 예약/예약 정보 확인을 위한 FloatingActionButton 추가 🦋

### DIFF
--- a/lib/presentation/views/main/block/main_bloc.dart
+++ b/lib/presentation/views/main/block/main_bloc.dart
@@ -9,6 +9,23 @@ part 'main_state.dart';
 class MainBloc extends Bloc<MainEvent, MainState> {
   // Event 등록
   MainBloc() : super(MainStateInitial()) {
-    on<MainEvent>((event, emit) {});
+    on<HomeTabLayoutCurrentPositionEvent>(
+      (event, emit) => _setHomeTabLayoutCurrentPosition(
+        event,
+        emit,
+      ),
+    );
+  }
+
+  /*
+    📌 ContentAreaComponent 에 있는 HomePagerScreen 의
+    현재 Tab 의 position 을 저장
+    즉, HomePagerScreen 의 currentPosition 을 저장
+  */
+  void _setHomeTabLayoutCurrentPosition(
+    HomeTabLayoutCurrentPositionEvent event,
+    Emitter<MainState> emit,
+  ) {
+    emit(HomeTabCurrentPositionState(event.currentPosition));
   }
 }

--- a/lib/presentation/views/main/block/main_event.dart
+++ b/lib/presentation/views/main/block/main_event.dart
@@ -3,3 +3,19 @@ part of 'main_bloc.dart';
 abstract class MainEvent extends Equatable {
   const MainEvent();
 }
+
+/*
+  📌 ContentAreaComponent 에 있는 HomePagerScreen 의
+  현재 Tab 의 position 을 저장
+  즉, HomePagerScreen 의 currentPosition 을 저장
+ */
+class HomeTabLayoutCurrentPositionEvent extends MainEvent {
+  final int currentPosition;
+  HomeTabLayoutCurrentPositionEvent(this.currentPosition);
+
+  @override
+  List<Object?> get props => [currentPosition];
+
+  @override
+  bool? get stringify => false;
+}

--- a/lib/presentation/views/main/block/main_state.dart
+++ b/lib/presentation/views/main/block/main_state.dart
@@ -11,3 +11,19 @@ class MainStateInitial extends MainState {
   @override
   bool? get stringify => false;
 }
+
+/*
+  📌 ContentAreaComponent 에 있는 HomePagerScreen 의
+  현재 Tab 의 position 임 즉, HomePagerScreen 의 currentPosition
+ */
+class HomeTabCurrentPositionState extends MainState {
+  final int currentPosition;
+  HomeTabCurrentPositionState(this.currentPosition);
+
+  @override
+  // TODO: implement props
+  List<Object?> get props => [currentPosition];
+
+  @override
+  bool? get stringify => false;
+}

--- a/lib/presentation/views/main/tabs/home/home_tab_screen.dart
+++ b/lib/presentation/views/main/tabs/home/home_tab_screen.dart
@@ -2,9 +2,12 @@ import 'package:animated_text_kit/animated_text_kit.dart';
 import 'package:auto_route/auto_route.dart';
 import 'package:expandable_bottom_sheet/expandable_bottom_sheet.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 import 'package:reservation_app/presentation/config/router/app_router.dart';
 
 import '../../../../utils/color_constants.dart';
+import '../../block/main_bloc.dart';
 import 'components/content_area_component.dart';
 import 'components/top_area_component.dart';
 
@@ -18,6 +21,8 @@ class HomeTabScreen extends StatefulWidget {
 class _HomeTabScreenState extends State<HomeTabScreen> {
   @override
   Widget build(BuildContext context) {
+    final mainBlock = BlocProvider.of<MainBloc>(context);
+
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.white,
@@ -36,12 +41,12 @@ class _HomeTabScreenState extends State<HomeTabScreen> {
               ),
             ],
             onTap: () {
-              print("Tap Event");
+              debugPrint("Tap Event");
             },
           ),
         ),
         leading: Padding(
-          padding: EdgeInsets.only(left: 10.0), // 왼쪽에만 8의 padding을 적용
+          padding: EdgeInsets.only(left: 10.0),
           child: Image.asset(
             "assets/images/logo_white.png",
             fit: BoxFit.cover,
@@ -77,6 +82,62 @@ class _HomeTabScreenState extends State<HomeTabScreen> {
           },
         ),
       ),
+      floatingActionButton: BlocBuilder<MainBloc, MainState>(
+        bloc: mainBlock,
+        builder: (context, state) {
+          if (state is HomeTabCurrentPositionState) {
+            if (state.currentPosition == 0 || state.currentPosition == 1) {
+              return floatingButtons() ?? Container();
+            } else {
+              return Container();
+            }
+          }
+
+          return Container();
+        },
+      ),
+    );
+  }
+
+  // Custom Floating Action Button
+  Widget? floatingButtons() {
+    return SpeedDial(
+      animatedIcon: AnimatedIcons.menu_close,
+      visible: true,
+      curve: Curves.bounceIn,
+      backgroundColor: ColorsConstants.splashText,
+      children: [
+        SpeedDialChild(
+          child: const Icon(
+            Icons.app_registration,
+            color: Colors.white,
+          ),
+          label: "예약",
+          labelStyle: const TextStyle(
+            fontWeight: FontWeight.w600,
+            color: Colors.white,
+            fontSize: 13.0,
+          ),
+          backgroundColor: ColorsConstants.splashText,
+          labelBackgroundColor: ColorsConstants.splashText,
+          onTap: () {},
+        ),
+        SpeedDialChild(
+          child: const Icon(
+            Icons.add_chart_rounded,
+            color: Colors.white,
+          ),
+          label: "예약정보 확인",
+          labelStyle: const TextStyle(
+            fontWeight: FontWeight.w600,
+            color: Colors.white,
+            fontSize: 13.0,
+          ),
+          backgroundColor: ColorsConstants.splashText,
+          labelBackgroundColor: ColorsConstants.splashText,
+          onTap: () {},
+        ),
+      ],
     );
   }
 }

--- a/lib/presentation/views/main/tabs/home/pager/home_pager_screen.dart
+++ b/lib/presentation/views/main/tabs/home/pager/home_pager_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reservation_app/presentation/utils/color_constants.dart';
+import 'package:reservation_app/presentation/views/main/block/main_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/home/tabs/home/content_home_tab_screen.dart';
 import 'package:reservation_app/presentation/views/main/tabs/home/tabs/location/content_location_tab_screen.dart';
 
@@ -96,6 +98,13 @@ class _HomePagerScreenState extends State<HomePagerScreen>
 
   @override
   Widget build(BuildContext context) {
+    final mainBlock = BlocProvider.of<MainBloc>(context)
+      ..add(
+        HomeTabLayoutCurrentPositionEvent(
+          _currentIndex,
+        ),
+      );
+
     return Container(
       decoration: BoxDecoration(
         color: ColorsConstants.background,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -350,6 +350,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  flutter_speed_dial:
+    dependency: "direct main"
+    description:
+      name: flutter_speed_dial
+      sha256: "698a037274a66dbae8697c265440e6acb6ab6cae9ac5f95c749e7944d8f28d41"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -909,6 +917,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
+  timelines:
+    dependency: "direct main"
+    description:
+      name: timelines
+      sha256: "40214f5ab772ff45459cb8c15e5f60505a6828af0c0eb1eec6f29ed911a4c1c5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,9 +62,9 @@ dependencies:
   cupertino_tabbar: ^2.0.0
   lottie: ^2.4.0
   grouped_list: ^5.1.2
-
-  # Map
   flutter_naver_map: ^1.0.2
+  timelines: ^0.1.0
+  flutter_speed_dial: ^7.0.0
 
   # Web View 띄우기
   url_launcher: ^6.1.11


### PR DESCRIPTION
## 🌸 FloatingActionButton 추가
- 클릭 시 **_예약/예약정보 확인_** 을 할 수 있도록 하기 위해 floatingActionButton 을 추가
  > - `flutter_speed_dial` 라이브러리를 사용하여 floatingActionButton 클릭 시 **_예약/예약정보 확인_** 2개의 sub floatingActionButton 이 나오도록 작업

- HomePagerScreen 의 TabLayout 이 **_홈_** 이거나 **_예약_** 일때만 floatingActionButton 이 보이도록하고, 나머지의 경우 보이지 않도록 설정
  > **_📌 참고_**
  > -
  > #### 📍 HomeTabScreen > HomePagerScreen 간 데이터 공유
  > - MainBloc 을 SharedViewModel 처럼 사용하여 전혀 다른 화면간에 데이터를 공유할 수 있도록 했음
  > - MainBloc 은 프로젝트 전체에서 화면간 데이터를 공유할 수 있음
  > #### 📍 로직
  > - MainBloc 에서 Event, State 를 만들어 HomePagerScreen 에서 currentPosition 을 항상 넣어줌
  > - HomeTabScreen 은 MainBloc 을 Observing 하고 있다가 currentPosition 이 0 이거나, 1 이면 floatingActionButton 을 보여주고, 아니면 빈 Container 를 보여줌

### 🌹 Dependency
- timelines 👉 예약을 `process_timeline` 형식으로 하기위해 적용
- flutter_speed_dial 👉 floatingActionButton 을 눌렀을 때 확장되는 sub floatingActionButton 을 생성하기 위해 적용

``` yaml
dependencies:
  timelines: ^0.1.0
  flutter_speed_dial: ^7.0.0
```