### PR TITLE
🦋 공지사항 기초 작업(API, Bloc) 🦋

### DIFF
--- a/lib/data/datasources/remote/notice/notice_api_service.dart
+++ b/lib/data/datasources/remote/notice/notice_api_service.dart
@@ -1,0 +1,15 @@
+
+import 'package:dio/dio.dart';
+import 'package:reservation_app/data/common/response/response_list_base.dart';
+import 'package:reservation_app/domain/model/notice/notice_model.dart';
+import 'package:retrofit/http.dart';
+
+part 'notice_api_service.g.dart';
+
+@RestApi()
+abstract class NoticeApiService {
+  factory NoticeApiService(Dio dio, {String? baseUrl}) = _NoticeApiService;
+  
+  @GET("/notices")
+  Future<BaseListResponse<NoticeModel>> getAllNoticeList();
+}

--- a/lib/data/datasources/remote/notice/notice_api_service.g.dart
+++ b/lib/data/datasources/remote/notice/notice_api_service.g.dart
@@ -1,0 +1,59 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'notice_api_service.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers
+
+class _NoticeApiService implements NoticeApiService {
+  _NoticeApiService(
+    this._dio, {
+    this.baseUrl,
+  });
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  @override
+  Future<BaseListResponse<NoticeModel>> getAllNoticeList() async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final Map<String, dynamic>? _data = null;
+    final _result = await _dio.fetch<Map<String, dynamic>>(
+        _setStreamType<BaseListResponse<NoticeModel>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/notices',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    final value = BaseListResponse<NoticeModel>.fromJson(
+      _result.data!,
+      (json) => NoticeModel.fromJson(json as Map<String, dynamic>),
+    );
+    return value;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+}

--- a/lib/data/datasources/remote/reservation/reservation_api_service.dart
+++ b/lib/data/datasources/remote/reservation/reservation_api_service.dart
@@ -1,6 +1,5 @@
 import 'package:dio/dio.dart';
 import 'package:reservation_app/data/model/reservation/reservation_target_date_response.dart';
-import 'package:reservation_app/domain/model/reservation/reservation_target_date_model.dart';
 import 'package:retrofit/http.dart';
 
 import '../../../common/response/response_list_base.dart';

--- a/lib/data/repository/notice/notice_repository_impl.dart
+++ b/lib/data/repository/notice/notice_repository_impl.dart
@@ -1,0 +1,34 @@
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:reservation_app/data/datasources/remote/notice/notice_api_service.dart';
+import 'package:reservation_app/domain/model/base/data_state.dart';
+import 'package:reservation_app/domain/model/notice/notice_model.dart';
+import 'package:reservation_app/domain/repository/notice/notice_repository.dart';
+
+class NoticeRepositoryImpl implements NoticeRepository {
+  final NoticeApiService _noticeApiService;
+  NoticeRepositoryImpl(this._noticeApiService);
+
+  @override
+  Future<DataState<List<NoticeModel>>> getAllNoticeList() async {
+    try {
+      final response = await _noticeApiService.getAllNoticeList();
+      final List<NoticeModel>? responseData = response.data;
+
+      if (response.success && responseData != null) {
+        if (responseData.isNotEmpty) {
+          debugPrint("noticeList 👇 \n ${responseData.toString()}");
+          return DataSuccess(responseData);
+        }
+
+        return DataSuccess([]);
+      }
+
+      return DataNetworkError(response.resultMsg);
+    } on DioException catch (error) {
+      debugPrint("🌹 DioException 👉 ${error.message}");
+      return DataError(error);
+    }
+  }
+}

--- a/lib/di/dependency_inection_graph.dart
+++ b/lib/di/dependency_inection_graph.dart
@@ -1,19 +1,24 @@
 import 'package:dio/dio.dart';
 import 'package:get_it/get_it.dart';
 import 'package:reservation_app/data/datasources/remote/banner/banner_api_service.dart';
+import 'package:reservation_app/data/datasources/remote/notice/notice_api_service.dart';
 import 'package:reservation_app/data/datasources/remote/reservation/reservation_api_service.dart';
 import 'package:reservation_app/data/repository/banner/banner_repository_impl.dart';
+import 'package:reservation_app/data/repository/notice/notice_repository_impl.dart';
 import 'package:reservation_app/data/repository/reservation/reservation_repository_impl.dart';
 import 'package:reservation_app/di/network/network_module.dart';
 import 'package:reservation_app/di/prefs/shared_pref_module.dart';
 import 'package:reservation_app/domain/repository/banner/banner_repository.dart';
+import 'package:reservation_app/domain/repository/notice/notice_repository.dart';
 import 'package:reservation_app/domain/repository/reservation/reservation_repository.dart';
 import 'package:reservation_app/domain/usecase/banner/get_all_banner_image_use_case.dart';
+import 'package:reservation_app/domain/usecase/notice/get_all_notice_list_use_case.dart';
 import 'package:reservation_app/domain/usecase/reservation/get_tartget_date_reservation_use_case.dart';
 import 'package:reservation_app/presentation/views/main/block/main_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/home/block/home_tab_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/home/tabs/home/bloc/content_home_tab_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/home/tabs/location/bloc/content_location_tab_bloc.dart';
+import 'package:reservation_app/presentation/views/main/tabs/home/tabs/notice/bloc/content_notice_tab_bloc.dart';
 import 'package:reservation_app/presentation/views/reservation/bloc/reservation_bloc.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -48,6 +53,9 @@ Future<void> initializeDependencies() async {
   locator.registerLazySingleton<ReservationApiService>(
     () => ReservationApiService(locator<Dio>()),
   );
+  locator.registerLazySingleton<NoticeApiService>(
+    () => NoticeApiService(locator<Dio>()),
+  );
 
   // 📌 Repository
   locator.registerLazySingleton<BannerRepository>(
@@ -56,6 +64,9 @@ Future<void> initializeDependencies() async {
   locator.registerLazySingleton<ReservationRepository>(
     () => ReservationRepositoryImpl(locator<ReservationApiService>()),
   );
+  locator.registerLazySingleton<NoticeRepository>(
+    () => NoticeRepositoryImpl(locator<NoticeApiService>()),
+  );
 
   // 📌 UseCase
   locator.registerLazySingleton<GetAllBannerImageUseCase>(
@@ -63,6 +74,9 @@ Future<void> initializeDependencies() async {
   );
   locator.registerLazySingleton<GetTargetDateReservationUseCase>(
     () => GetTargetDateReservationUseCase(locator<ReservationRepository>()),
+  );
+  locator.registerLazySingleton<GetAllNoticeListUseCase>(
+    () => GetAllNoticeListUseCase(locator<NoticeRepository>()),
   );
 
   // 📌 Block
@@ -78,5 +92,8 @@ Future<void> initializeDependencies() async {
   );
   locator.registerFactory(
     () => ReservationBloc(),
+  );
+  locator.registerFactory(
+    () => ContentNoticeTabBloc(locator<GetAllNoticeListUseCase>()),
   );
 }

--- a/lib/domain/model/member/member_model.dart
+++ b/lib/domain/model/member/member_model.dart
@@ -1,0 +1,23 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'member_model.g.dart';
+
+@JsonSerializable()
+class MemberModel extends Equatable {
+  final int id;
+  final String email;
+  final String role;
+
+  MemberModel({
+    required this.id,
+    required this.email,
+    required this.role,
+  });
+
+  factory MemberModel.fromJson(Map<String, dynamic> json) => _$MemberModelFromJson(json);
+  Map<String, dynamic> toJson() => _$MemberModelToJson(this);
+
+  @override
+  List<Object?> get props => [id, email, role];
+}

--- a/lib/domain/model/member/member_model.g.dart
+++ b/lib/domain/model/member/member_model.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'member_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MemberModel _$MemberModelFromJson(Map<String, dynamic> json) => MemberModel(
+      id: json['id'] as int,
+      email: json['email'] as String,
+      role: json['role'] as String,
+    );
+
+Map<String, dynamic> _$MemberModelToJson(MemberModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'email': instance.email,
+      'role': instance.role,
+    };

--- a/lib/domain/model/notice/image/notice_image_model.dart
+++ b/lib/domain/model/notice/image/notice_image_model.dart
@@ -1,0 +1,23 @@
+
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'notice_image_model.g.dart';
+
+@JsonSerializable()
+class NoticeImageModel extends Equatable {
+  final int id;
+  @JsonKey(name: 'uniqueName')
+  final String imageUrl;
+
+  NoticeImageModel({
+    required this.id,
+    required this.imageUrl,
+  });
+
+  factory NoticeImageModel.fromJson(Map<String, dynamic> json) => _$NoticeImageModelFromJson(json);
+  Map<String, dynamic> toJson() => _$NoticeImageModelToJson(this);
+
+  @override
+  List<Object?> get props => [id, imageUrl];
+}

--- a/lib/domain/model/notice/image/notice_image_model.g.dart
+++ b/lib/domain/model/notice/image/notice_image_model.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'notice_image_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+NoticeImageModel _$NoticeImageModelFromJson(Map<String, dynamic> json) =>
+    NoticeImageModel(
+      id: json['id'] as int,
+      imageUrl: json['uniqueName'] as String,
+    );
+
+Map<String, dynamic> _$NoticeImageModelToJson(NoticeImageModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'uniqueName': instance.imageUrl,
+    };

--- a/lib/domain/model/notice/notice_model.dart
+++ b/lib/domain/model/notice/notice_model.dart
@@ -1,0 +1,41 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:reservation_app/domain/model/member/member_model.dart';
+import 'package:reservation_app/domain/model/notice/image/notice_image_model.dart';
+
+part 'notice_model.g.dart';
+
+@JsonSerializable()
+class NoticeModel extends Equatable {
+  final int id;
+  final String title;
+  final String content;
+  final MemberModel member;
+  final List<NoticeImageModel> images;
+  final String createdAt;
+  final String modifiedAt;
+
+  NoticeModel({
+    required this.id,
+    required this.title,
+    required this.content,
+    required this.member,
+    required this.images,
+    required this.createdAt,
+    required this.modifiedAt,
+  });
+
+  factory NoticeModel.fromJson(Map<String, dynamic> json) => _$NoticeModelFromJson(json);
+  Map<String, dynamic> toJson() => _$NoticeModelToJson(this);
+
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+        content,
+        member,
+        images,
+        createdAt,
+        modifiedAt,
+      ];
+}

--- a/lib/domain/model/notice/notice_model.g.dart
+++ b/lib/domain/model/notice/notice_model.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'notice_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+NoticeModel _$NoticeModelFromJson(Map<String, dynamic> json) => NoticeModel(
+      id: json['id'] as int,
+      title: json['title'] as String,
+      content: json['content'] as String,
+      member: MemberModel.fromJson(json['member'] as Map<String, dynamic>),
+      images: (json['images'] as List<dynamic>)
+          .map((e) => NoticeImageModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      createdAt: json['createdAt'] as String,
+      modifiedAt: json['modifiedAt'] as String,
+    );
+
+Map<String, dynamic> _$NoticeModelToJson(NoticeModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'content': instance.content,
+      'member': instance.member,
+      'images': instance.images,
+      'createdAt': instance.createdAt,
+      'modifiedAt': instance.modifiedAt,
+    };

--- a/lib/domain/repository/notice/notice_repository.dart
+++ b/lib/domain/repository/notice/notice_repository.dart
@@ -1,0 +1,7 @@
+
+import 'package:reservation_app/domain/model/base/data_state.dart';
+import 'package:reservation_app/domain/model/notice/notice_model.dart';
+
+abstract class NoticeRepository {
+  Future<DataState<List<NoticeModel>>> getAllNoticeList();
+}

--- a/lib/domain/usecase/notice/get_all_notice_list_use_case.dart
+++ b/lib/domain/usecase/notice/get_all_notice_list_use_case.dart
@@ -1,0 +1,13 @@
+
+import 'package:reservation_app/domain/model/base/data_state.dart';
+import 'package:reservation_app/domain/model/notice/notice_model.dart';
+import 'package:reservation_app/domain/repository/notice/notice_repository.dart';
+
+class GetAllNoticeListUseCase {
+  final NoticeRepository _noticeRepository;
+  GetAllNoticeListUseCase(this._noticeRepository);
+
+  Future<DataState<List<NoticeModel>>> invoke() {
+    return _noticeRepository.getAllNoticeList();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/foundation.dart' as foundation;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_naver_map/flutter_naver_map.dart';
 import 'package:reservation_app/presentation/config/router/app_router.dart';
 import 'package:reservation_app/presentation/config/themes/app_theme.dart';
 import 'package:reservation_app/presentation/views/main/block/main_bloc.dart';
+
 import 'di/dependency_inection_graph.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
+import 'presentation/views/main/tabs/home/tabs/notice/bloc/content_notice_tab_bloc.dart';
 
 bool get isIOS => foundation.defaultTargetPlatform == TargetPlatform.iOS;
 
@@ -15,9 +17,11 @@ void main() async {
 
   await initializeDependencies();
 
-  await NaverMapSdk.instance.initialize(clientId: 'sz1yl84rs6', onAuthFailed: (error) {
-    debugPrint('💛 Naver ClientId Auth failed 👉 $error');
-  });
+  await NaverMapSdk.instance.initialize(
+      clientId: 'sz1yl84rs6',
+      onAuthFailed: (error) {
+        debugPrint('💛 Naver ClientId Auth failed 👉 $error');
+      });
 
   runApp(const MyApp());
 }
@@ -34,15 +38,20 @@ class MyApp extends StatelessWidget {
           BlocProvider<MainBloc>(
             create: (context) => locator<MainBloc>(),
           ),
+          BlocProvider<ContentNoticeTabBloc>(
+            create: (create) => locator<ContentNoticeTabBloc>(),
+          ),
         ],
         child: MaterialApp.router(
           debugShowCheckedModeBanner: false,
-          localizationsDelegates: [ // 다국어 설정
+          localizationsDelegates: [
+            // 다국어 설정
             GlobalMaterialLocalizations.delegate,
             GlobalWidgetsLocalizations.delegate,
             GlobalCupertinoLocalizations.delegate,
           ],
-          locale: Locale('ko', 'KR'), // 대한민국 언어 설정
+          locale: Locale('ko', 'KR'),
+          // 대한민국 언어 설정
           supportedLocales: [
             const Locale('en', 'US'), // English
             const Locale('ko', 'KR'), // 대한민국 언어 설정

--- a/lib/presentation/views/main/tabs/home/pager/home_pager_screen.dart
+++ b/lib/presentation/views/main/tabs/home/pager/home_pager_screen.dart
@@ -4,6 +4,7 @@ import 'package:reservation_app/presentation/utils/color_constants.dart';
 import 'package:reservation_app/presentation/views/main/block/main_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/home/tabs/home/content_home_tab_screen.dart';
 import 'package:reservation_app/presentation/views/main/tabs/home/tabs/location/content_location_tab_screen.dart';
+import 'package:reservation_app/presentation/views/main/tabs/home/tabs/notice/content_notice_tab_screen.dart';
 
 class HomePagerScreen extends StatefulWidget {
   const HomePagerScreen({Key? key}) : super(key: key);
@@ -172,7 +173,7 @@ class _HomePagerScreenState extends State<HomePagerScreen>
               children: <Widget>[
                 ContentHomeTabScreen(), // 홈
                 Center(child: Text("예약")),
-                Center(child: Text("공지사항")),
+                ContentNoticeTabScreen(), // 공지사항
                 Center(child: Text("알림")),
                 ContentLocationTabScreen(), // 오시는 길
               ],

--- a/lib/presentation/views/main/tabs/home/tabs/notice/bloc/content_notice_tab_bloc.dart
+++ b/lib/presentation/views/main/tabs/home/tabs/notice/bloc/content_notice_tab_bloc.dart
@@ -1,0 +1,66 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reservation_app/domain/model/base/data_state.dart';
+import 'package:reservation_app/domain/model/notice/notice_model.dart';
+import 'package:reservation_app/domain/usecase/notice/get_all_notice_list_use_case.dart';
+
+part 'content_notice_tab_event.dart';
+
+part 'content_notice_tab_state.dart';
+
+class ContentNoticeTabBloc
+    extends Bloc<ContentNoticeTabEvent, ContentNoticeTabState> {
+  final GetAllNoticeListUseCase _getAllNoticeListUseCase;
+
+  ContentNoticeTabBloc(this._getAllNoticeListUseCase)
+      : super(ContentNoticeTabInitial()) {
+    on<ContentNoticeTabNoticeListEvent>(
+      (event, emit) => _getNoticeList(event, emit),
+    );
+  }
+
+  void _getNoticeList(
+    ContentNoticeTabNoticeListEvent event,
+    Emitter<ContentNoticeTabState> emit,
+  ) async {
+    emit(const ContentNoticeTabStateLoading());
+
+    final response = await _getAllNoticeListUseCase.invoke();
+
+    if (response is DataSuccess) {
+      emit(
+        ContentNoticeTabStateNoticeList(
+          noticeList: response.data ?? [],
+        ),
+      );
+    } else if (response is DataError) {
+      debugPrint(
+        "🌹 ContentNoticeTabBloc DataError message 👉 ${response.error?.message}",
+      );
+      emit(
+        ContentNoticeTabStateNoticeListFailed(
+          message: '알 수 없는 오류가 발생하였습니다. \n 잠시 후 다시 시도해주세요.',
+        ),
+      );
+    } else if (response is DataNetworkError) {
+      debugPrint(
+        "🌹 ContentNoticeTabBloc DataNetworkError message 👉 ${response.error?.message}",
+      );
+      emit(
+        ContentNoticeTabStateNoticeListFailed(
+          message: '네트워크가 원활하지 않습니다. \n 잠시 후 다시 시도해주세요.',
+        ),
+      );
+    } else {
+      debugPrint(
+        "🌹 ContentNoticeTabBloc DataError message 👉 ${response.error?.message}",
+      );
+      emit(
+        ContentNoticeTabStateNoticeListFailed(
+          message: '알 수 없는 오류가 발생하였습니다. \n 잠시 후 다시 시도해주세요.',
+        ),
+      );
+    }
+  }
+}

--- a/lib/presentation/views/main/tabs/home/tabs/notice/bloc/content_notice_tab_event.dart
+++ b/lib/presentation/views/main/tabs/home/tabs/notice/bloc/content_notice_tab_event.dart
@@ -1,0 +1,14 @@
+part of 'content_notice_tab_bloc.dart';
+
+abstract class ContentNoticeTabEvent extends Equatable {
+  const ContentNoticeTabEvent();
+}
+
+class ContentNoticeTabNoticeListEvent extends ContentNoticeTabEvent {
+  @override
+  List<Object?> get props => [];
+
+  @override
+  bool? get stringify => false;
+}
+

--- a/lib/presentation/views/main/tabs/home/tabs/notice/bloc/content_notice_tab_state.dart
+++ b/lib/presentation/views/main/tabs/home/tabs/notice/bloc/content_notice_tab_state.dart
@@ -1,0 +1,44 @@
+part of 'content_notice_tab_bloc.dart';
+
+abstract class ContentNoticeTabState extends Equatable {
+  const ContentNoticeTabState();
+}
+
+class ContentNoticeTabInitial extends ContentNoticeTabState {
+  @override
+  List<Object?> get props => [];
+}
+
+class ContentNoticeTabStateLoading extends ContentNoticeTabState {
+  const ContentNoticeTabStateLoading();
+
+  @override
+  List<Object?> get props => [];
+
+  @override
+  bool? get stringify => false;
+}
+
+class ContentNoticeTabStateNoticeList extends ContentNoticeTabState {
+  final List<NoticeModel> noticeList;
+  const ContentNoticeTabStateNoticeList({
+    required this.noticeList,
+  });
+
+  @override
+  List<Object?> get props => [noticeList];
+
+  @override
+  bool? get stringify => false;
+}
+
+class ContentNoticeTabStateNoticeListFailed extends ContentNoticeTabState {
+  final String message;
+  const ContentNoticeTabStateNoticeListFailed({required this.message});
+
+  @override
+  List<Object?> get props => [message];
+
+  @override
+  bool? get stringify => false;
+}

--- a/lib/presentation/views/main/tabs/home/tabs/notice/content_notice_tab_screen.dart
+++ b/lib/presentation/views/main/tabs/home/tabs/notice/content_notice_tab_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reservation_app/presentation/views/main/tabs/home/tabs/notice/bloc/content_notice_tab_bloc.dart';
+
+class ContentNoticeTabScreen extends StatefulWidget {
+  const ContentNoticeTabScreen({Key? key}) : super(key: key);
+
+  @override
+  State<ContentNoticeTabScreen> createState() => _ContentNoticeTabScreenState();
+}
+
+class _ContentNoticeTabScreenState extends State<ContentNoticeTabScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final contentNoticeTabBloc =
+        BlocProvider.of<ContentNoticeTabBloc>(context).add(
+      ContentNoticeTabNoticeListEvent(),
+    );
+
+    return Center(child: Text("공지사항"));
+  }
+}


### PR DESCRIPTION
## 🌸 공지사항
- 공지사항 작업에 앞서 공지사항을 전부 가져오는 **_/notices_** API 추가

---
### 🌹 Domain Layer
---
#### 🌷 Model
- 공지사항 API Response에서 사용자에게 직접 보여줄 데이터만 받아오도록 Model 구현
- NoticeModel, NoticeImageModel, MemberModel

#### 🌷 Repository
- 공지사항 API 를 Result 패턴에 맞춰 Return 할 수 있는 함수 구현

#### 🌷 UseCase
- 공지사항 전체 List를 가져오는 UseCase 추가

---
### 🌹 Data Layer
---
#### 🌷 Model
- 서버의 데이터를 전부가져오는 Model 구현해야 하나 아직 서버쪽에서도 `/Notices` 관련하여 응답값이 정확하게 안정해져 있기때문에 Data Layer 의 Model 은 일단 구현안함

#### 🌷 DataSource
- NoticeApiService 👉 /notice API 관련 통신을 담당하는 Service 생성

#### 🌷 RepositoryImpl
- NoticeRepository 를 구현하여 서버에서 받아온 Response 를 **_Result 패턴인 `DataState` 에 맞게 끔 파싱_** 하여 구현 완료

---
### 🌹 Presentation Layer
---
- 공지사항 관련 기초작업(Bloc 연결 후 API 통신 잘 되는지 확인)

#### 🌷 View (ContentNoticeTabScreen.dart)
- `lib/presentation/views/main/tabs/home/tabs/notice/content_notice_tab_screen.dart` 하위에 공지사항 Tab 으로 사용될 View 생성

#### 🌷 Bloc (ContentNoticeTabBloc.dart)
- `lib/presentation/views/main/tabs/home/tabs/notice/bloc/content_notice_tab_bloc.dart` 하위에 공지사항 View 의 ViewModel 로 사용될 Bloc 생성
- ContentNoticeTabEvent 👉 공지사항 API를 호출하는 Event 생성
- ContentNoticeTabState 👉 공지사항 API를 호출하는 동안 State 패턴을 활용하여 Loading, Success, Failed 상태 생성

#### 🌷 BlocProvider
- `ContentNoticeTabBloc.dart` 은 홈화면 최상위 Toolbar 에서도 사용을 해야하므로, **_`SharedViewModel` 개념을 적용하여_** 제일 최상단에서 Provider 해줬음

---
### 🌹 DI(dependency_injection_graph.dart)
---
- NoticeApiService, NoticeRepository, GetAllNoticeListUseCase, ContentNoticeTabBloc 으로 가는 Dependency Graph 생성