### PR TITLE
🦋 예약 기능 2️⃣ - 좌석선택 🦋

### DIFF
--- a/lib/data/common/response/response_list_base.dart
+++ b/lib/data/common/response/response_list_base.dart
@@ -4,7 +4,7 @@ import 'package:json_annotation/json_annotation.dart';
 part 'response_list_base.g.dart';
 
 @JsonSerializable(genericArgumentFactories: true)
-class BaseListResponse<T extends Equatable> {
+class BaseListResponse<T> {
   bool success;
   String? resultMsg;
   int code;

--- a/lib/data/common/response/response_list_base.g.dart
+++ b/lib/data/common/response/response_list_base.g.dart
@@ -6,7 +6,7 @@ part of 'response_list_base.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-BaseListResponse<T> _$BaseListResponseFromJson<T extends Equatable>(
+BaseListResponse<T> _$BaseListResponseFromJson<T>(
   Map<String, dynamic> json,
   T Function(Object? json) fromJsonT,
 ) =>
@@ -17,7 +17,7 @@ BaseListResponse<T> _$BaseListResponseFromJson<T extends Equatable>(
       data: (json['data'] as List<dynamic>?)?.map(fromJsonT).toList(),
     );
 
-Map<String, dynamic> _$BaseListResponseToJson<T extends Equatable>(
+Map<String, dynamic> _$BaseListResponseToJson<T>(
   BaseListResponse<T> instance,
   Object? Function(T value) toJsonT,
 ) =>

--- a/lib/data/datasources/remote/reservation/reservation_api_service.dart
+++ b/lib/data/datasources/remote/reservation/reservation_api_service.dart
@@ -1,5 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:reservation_app/data/model/reservation/reservation_target_date_response.dart';
+import 'package:reservation_app/domain/model/reservation/enum/part_time.dart';
+import 'package:reservation_app/domain/model/seat/enum/seat_type.dart';
 import 'package:retrofit/http.dart';
 
 import '../../../common/response/response_list_base.dart';
@@ -11,8 +13,17 @@ abstract class ReservationApiService {
   factory ReservationApiService(Dio dio, {String? baseUrl}) =
       _ReservationApiService;
 
+  // PartTime 에 신경쓰지 않고 특정 날짜의 모든 좌석 List 를 가져옴
   @GET("/reservation/seats/date")
-  Future<BaseListResponse<ReservationTargetDateResponse>> getTargetDateReservation(
+  Future<BaseListResponse<ReservationTargetDateResponse>>
+      getTargetDateReservation(
     @Query("findDate") String date,
+  );
+
+  // 특정 날짜의 원하는 PartTime 에 남아있는 좌석 List 를 가져옴
+  @GET("/reservation/seats")
+  Future<BaseListResponse<SeatType>> getTargetPartTimeDateReservation(
+    @Query("timeType") PartTime partTime,
+    @Query("reservationDateTime") String date,
   );
 }

--- a/lib/data/datasources/remote/reservation/reservation_api_service.g.dart
+++ b/lib/data/datasources/remote/reservation/reservation_api_service.g.dart
@@ -46,6 +46,38 @@ class _ReservationApiService implements ReservationApiService {
     return value;
   }
 
+  @override
+  Future<BaseListResponse<SeatType>> getTargetPartTimeDateReservation(
+    partTime,
+    date,
+  ) async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{
+      r'timeType': partTime.toJson(),
+      r'reservationDateTime': date,
+    };
+    final _headers = <String, dynamic>{};
+    final Map<String, dynamic>? _data = null;
+    final _result = await _dio.fetch<Map<String, dynamic>>(
+        _setStreamType<BaseListResponse<SeatType>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/reservation/seats',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    final value = BaseListResponse<SeatType>.fromJson(
+      _result.data!,
+          (json) => SeatTypeExtension.fromJson(json.toString()),
+    );
+    return value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/data/repository/reservation/reservation_repository_impl.dart
+++ b/lib/data/repository/reservation/reservation_repository_impl.dart
@@ -85,6 +85,10 @@ class ReservationRepositoryImpl implements ReservationRepository {
           String prefix = count <= 3 ? 'a' : count >= 4 && count < 6 ? 'b' : 'c';
           final seatList = _parseByPartTime(responseData, prefix,);
 
+          if (prefix == 'a' && seatList.length < count) {
+            return DataSuccess([]);
+          }
+
           final mappingList = seatList
               .map(
                 (item) => ReservationTargetPartTimeSeatModel(

--- a/lib/data/repository/reservation/reservation_repository_impl.dart
+++ b/lib/data/repository/reservation/reservation_repository_impl.dart
@@ -89,6 +89,7 @@ class ReservationRepositoryImpl implements ReservationRepository {
               .map(
                 (item) => ReservationTargetPartTimeSeatModel(
                   remainSeatList: item,
+                  isSelected: false
                 ),
               )
               .toList();

--- a/lib/di/dependency_inection_graph.dart
+++ b/lib/di/dependency_inection_graph.dart
@@ -13,6 +13,7 @@ import 'package:reservation_app/domain/repository/notice/notice_repository.dart'
 import 'package:reservation_app/domain/repository/reservation/reservation_repository.dart';
 import 'package:reservation_app/domain/usecase/banner/get_all_banner_image_use_case.dart';
 import 'package:reservation_app/domain/usecase/notice/get_all_notice_list_use_case.dart';
+import 'package:reservation_app/domain/usecase/reservation/get_reservation_target_part_time_use_case.dart';
 import 'package:reservation_app/domain/usecase/reservation/get_tartget_date_reservation_use_case.dart';
 import 'package:reservation_app/presentation/views/main/block/main_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/home/block/home_tab_bloc.dart';
@@ -77,6 +78,9 @@ Future<void> initializeDependencies() async {
   );
   locator.registerLazySingleton<GetAllNoticeListUseCase>(
     () => GetAllNoticeListUseCase(locator<NoticeRepository>()),
+  );
+  locator.registerLazySingleton<GetReservationTargetPartTimeUseCase>(
+    () => GetReservationTargetPartTimeUseCase(locator<ReservationRepository>()),
   );
 
   // 📌 Block

--- a/lib/di/dependency_inection_graph.dart
+++ b/lib/di/dependency_inection_graph.dart
@@ -21,6 +21,7 @@ import 'package:reservation_app/presentation/views/main/tabs/home/tabs/home/bloc
 import 'package:reservation_app/presentation/views/main/tabs/home/tabs/location/bloc/content_location_tab_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/home/tabs/notice/bloc/content_notice_tab_bloc.dart';
 import 'package:reservation_app/presentation/views/reservation/bloc/reservation_bloc.dart';
+import 'package:reservation_app/presentation/views/reservation/bloc/second/reservation_second_bloc.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'local/local_module.dart';
@@ -96,6 +97,9 @@ Future<void> initializeDependencies() async {
   );
   locator.registerFactory(
     () => ReservationBloc(),
+  );
+  locator.registerFactory(
+    () => ReservationSecondBloc(locator<GetReservationTargetPartTimeUseCase>()),
   );
   locator.registerFactory(
     () => ContentNoticeTabBloc(locator<GetAllNoticeListUseCase>()),

--- a/lib/domain/model/reservation/enum/part_time.dart
+++ b/lib/domain/model/reservation/enum/part_time.dart
@@ -9,3 +9,19 @@ enum PartTime {
   @JsonValue('PART_C')
   partC
 }
+
+// Retrofit Query 에 Enum 을 넣기위한 대책
+extension PartTimeExtension on PartTime {
+  String toJson() {
+    switch (this) {
+      case PartTime.partA:
+        return 'PART_A';
+      case PartTime.partB:
+        return 'PART_B';
+      case PartTime.partC:
+        return 'PART_C';
+      default:
+        throw ArgumentError('Invalid enum value: $this');
+    }
+  }
+}

--- a/lib/domain/model/reservation/reservation_target_part_time_seat_model.dart
+++ b/lib/domain/model/reservation/reservation_target_part_time_seat_model.dart
@@ -1,0 +1,25 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:reservation_app/domain/model/seat/enum/seat_type.dart';
+
+part 'reservation_target_part_time_seat_model.g.dart';
+
+@JsonSerializable()
+class ReservationTargetPartTimeSeatModel extends Equatable {
+  final SeatType remainSeatList;
+
+  ReservationTargetPartTimeSeatModel({
+    required this.remainSeatList,
+  });
+
+  factory ReservationTargetPartTimeSeatModel.fromJson(
+    Map<String, dynamic> json,
+  ) =>
+      _$ReservationTargetPartTimeSeatModelFromJson(json);
+
+  Map<String, dynamic> toJson() =>
+      _$ReservationTargetPartTimeSeatModelToJson(this);
+
+  @override
+  List<Object?> get props => [remainSeatList];
+}

--- a/lib/domain/model/reservation/reservation_target_part_time_seat_model.dart
+++ b/lib/domain/model/reservation/reservation_target_part_time_seat_model.dart
@@ -7,9 +7,11 @@ part 'reservation_target_part_time_seat_model.g.dart';
 @JsonSerializable()
 class ReservationTargetPartTimeSeatModel extends Equatable {
   final SeatType remainSeatList;
+  final bool isSelected;
 
   ReservationTargetPartTimeSeatModel({
     required this.remainSeatList,
+    required this.isSelected,
   });
 
   factory ReservationTargetPartTimeSeatModel.fromJson(
@@ -20,6 +22,19 @@ class ReservationTargetPartTimeSeatModel extends Equatable {
   Map<String, dynamic> toJson() =>
       _$ReservationTargetPartTimeSeatModelToJson(this);
 
+  ReservationTargetPartTimeSeatModel copyWith({
+    SeatType? remainSeatList,
+    bool? isSelected,
+  }) {
+    return ReservationTargetPartTimeSeatModel(
+      remainSeatList: remainSeatList ?? this.remainSeatList,
+      isSelected: isSelected ?? this.isSelected,
+    );
+  }
+
   @override
-  List<Object?> get props => [remainSeatList];
+  List<Object?> get props => [remainSeatList, isSelected];
+
+  @override
+  bool? get stringify => true;
 }

--- a/lib/domain/model/reservation/reservation_target_part_time_seat_model.g.dart
+++ b/lib/domain/model/reservation/reservation_target_part_time_seat_model.g.dart
@@ -10,12 +10,14 @@ ReservationTargetPartTimeSeatModel _$ReservationTargetPartTimeSeatModelFromJson(
         Map<String, dynamic> json) =>
     ReservationTargetPartTimeSeatModel(
       remainSeatList: $enumDecode(_$SeatTypeEnumMap, json['remainSeatList']),
+      isSelected: json['isSelected'] as bool,
     );
 
 Map<String, dynamic> _$ReservationTargetPartTimeSeatModelToJson(
         ReservationTargetPartTimeSeatModel instance) =>
     <String, dynamic>{
       'remainSeatList': _$SeatTypeEnumMap[instance.remainSeatList]!,
+      'isSelected': instance.isSelected,
     };
 
 const _$SeatTypeEnumMap = {

--- a/lib/domain/model/reservation/reservation_target_part_time_seat_model.g.dart
+++ b/lib/domain/model/reservation/reservation_target_part_time_seat_model.g.dart
@@ -1,0 +1,32 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'reservation_target_part_time_seat_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ReservationTargetPartTimeSeatModel _$ReservationTargetPartTimeSeatModelFromJson(
+        Map<String, dynamic> json) =>
+    ReservationTargetPartTimeSeatModel(
+      remainSeatList: $enumDecode(_$SeatTypeEnumMap, json['remainSeatList']),
+    );
+
+Map<String, dynamic> _$ReservationTargetPartTimeSeatModelToJson(
+        ReservationTargetPartTimeSeatModel instance) =>
+    <String, dynamic>{
+      'remainSeatList': _$SeatTypeEnumMap[instance.remainSeatList]!,
+    };
+
+const _$SeatTypeEnumMap = {
+  SeatType.a1: 'A_1',
+  SeatType.a2: 'A_2',
+  SeatType.a3: 'A_3',
+  SeatType.a4: 'A_4',
+  SeatType.a5: 'A_5',
+  SeatType.a6: 'A_6',
+  SeatType.a7: 'A_7',
+  SeatType.a8: 'A_8',
+  SeatType.b: 'B',
+  SeatType.c: 'C',
+};

--- a/lib/domain/model/seat/enum/seat_type.dart
+++ b/lib/domain/model/seat/enum/seat_type.dart
@@ -23,3 +23,57 @@ enum SeatType {
   @JsonValue('C')
   c
 }
+
+extension SeatTypeExtension on SeatType {
+  static SeatType fromJson(String json) {
+    switch (json) {
+      case 'A_1':
+        return SeatType.a1;
+      case 'A_2':
+        return SeatType.a2;
+      case 'A_3':
+        return SeatType.a3;
+      case 'A_4':
+        return SeatType.a4;
+      case 'A_5':
+        return SeatType.a5;
+      case 'A_6':
+        return SeatType.a6;
+      case 'A_7':
+        return SeatType.a7;
+      case 'A_8':
+        return SeatType.a8;
+      case 'B':
+        return SeatType.b;
+      case 'C':
+        return SeatType.c;
+      default:
+        throw ArgumentError('Invalid JSON value for SeatType: $json');
+    }
+  }
+
+  String toJson() {
+    switch (this) {
+      case SeatType.a1:
+        return 'A_1';
+      case SeatType.a2:
+        return 'A_2';
+      case SeatType.a3:
+        return 'A_3';
+      case SeatType.a4:
+        return 'A_4';
+      case SeatType.a5:
+        return 'A_5';
+      case SeatType.a6:
+        return 'A_6';
+      case SeatType.a7:
+        return 'A_7';
+      case SeatType.a8:
+        return 'A_8';
+      case SeatType.b:
+        return 'B';
+      case SeatType.c:
+        return 'C';
+    }
+  }
+}

--- a/lib/domain/repository/reservation/reservation_repository.dart
+++ b/lib/domain/repository/reservation/reservation_repository.dart
@@ -1,8 +1,18 @@
-
+import 'package:reservation_app/domain/model/reservation/enum/part_time.dart';
 import 'package:reservation_app/domain/model/reservation/reservation_target_date_model.dart';
+import 'package:reservation_app/domain/model/reservation/reservation_target_part_time_seat_model.dart';
 
 import '../../model/base/data_state.dart';
 
 abstract class ReservationRepository {
-  Future<DataState<List<ReservationTargetDateModel>>> getTargetDateReservation(DateTime date);
+  Future<DataState<List<ReservationTargetDateModel>>> getTargetDateReservation(
+    DateTime date,
+  );
+
+  Future<DataState<List<ReservationTargetPartTimeSeatModel>>>
+      getTargetPartTimeReservation(
+    PartTime partTime,
+    DateTime date,
+    int count,
+  );
 }

--- a/lib/domain/usecase/reservation/get_reservation_target_part_time_use_case.dart
+++ b/lib/domain/usecase/reservation/get_reservation_target_part_time_use_case.dart
@@ -1,0 +1,18 @@
+import 'package:reservation_app/domain/model/base/data_state.dart';
+import 'package:reservation_app/domain/model/reservation/enum/part_time.dart';
+import 'package:reservation_app/domain/model/reservation/reservation_target_part_time_seat_model.dart';
+import 'package:reservation_app/domain/repository/reservation/reservation_repository.dart';
+
+class GetReservationTargetPartTimeUseCase {
+  final ReservationRepository _reservationRepository;
+
+  GetReservationTargetPartTimeUseCase(this._reservationRepository);
+
+  Future<DataState<List<ReservationTargetPartTimeSeatModel>>> invoke(
+    PartTime partTime,
+    DateTime date,
+    int count,
+  ) {
+    return _reservationRepository.getTargetPartTimeReservation(partTime, date, count);
+  }
+}

--- a/lib/presentation/utils/color_constants.dart
+++ b/lib/presentation/utils/color_constants.dart
@@ -37,11 +37,13 @@ class ColorsConstants {
   // Others Widgets
   static const Color card = Color(0x20FFFFFF);
   static const Color divider = Color(0xFF333333);
+  static const Color boldColor = Color(0xFF000000);
   static const Color error = Color(0xfffe0012);
   static const Color success = Color(0xFF04FD7F);
   static const Color delete = Color(0xfffe0012);
 
   // Reservation Process Timelines
+  static const Color strokeColor = Color(0xFF152348);
   static const Color inProgressColor = Color(0xFF4682B4);
   static const Color completeColor = Color(0xFF87CEEB);
   static const Color todoColor = Color(0xffd1d2d7);

--- a/lib/presentation/utils/color_constants.dart
+++ b/lib/presentation/utils/color_constants.dart
@@ -41,6 +41,8 @@ class ColorsConstants {
   static const Color error = Color(0xfffe0012);
   static const Color success = Color(0xFF04FD7F);
   static const Color delete = Color(0xfffe0012);
+  static const Color guideBackground = Color(0xFFF5F5F5);
+  static const Color guideText = Color(0xFF777777);
 
   // Reservation Process Timelines
   static const Color strokeColor = Color(0xFF152348);

--- a/lib/presentation/utils/constants.dart
+++ b/lib/presentation/utils/constants.dart
@@ -7,4 +7,7 @@ class Constants {
     '본인인증',
     '예약완료',
   ];
+
+  static const dataError = "알 수 없는 오류가 발생하였습니다. \n 잠시 후 다시 시도해주세요.";
+  static const networkError = "네트워크가 원활하지 않습니다. \n 잠시 후 다시 시도해주세요.";
 }

--- a/lib/presentation/utils/date_time_utils.dart
+++ b/lib/presentation/utils/date_time_utils.dart
@@ -21,4 +21,9 @@ class DateTimeUtils {
   static String dateTimeToString({required String pattern, required DateTime date}) {
     return DateFormat(pattern).format(date);
   }
+
+  // 현재 날짜에 맞는 "요일" 가져오기
+  static String dateTimeToWeekDay({required DateTime date}) {
+    return DateFormat('EEEE', 'ko_KR').format(date);
+  }
 }

--- a/lib/presentation/utils/dialog_utils.dart
+++ b/lib/presentation/utils/dialog_utils.dart
@@ -100,6 +100,7 @@ class DialogUtils {
     required String message,
     bool enableCancelBtn = false,
     bool enableAutoCancel = true,
+    void Function()? onConfirmClick
   }) {
     showDialog(
       context: context,
@@ -187,6 +188,10 @@ class DialogUtils {
                       Expanded(
                         child: ElevatedButton(
                           onPressed: () {
+                            if (onConfirmClick != null) {
+                              onConfirmClick();
+                            }
+
                             Navigator.of(context).pop();
                           },
                           style: ButtonStyle(

--- a/lib/presentation/utils/list_extensions.dart
+++ b/lib/presentation/utils/list_extensions.dart
@@ -1,0 +1,11 @@
+/// 📌 List 의 확장함수
+/// List 에서 map 을 사용할때 List 의 index 또한 같이 사용할 수 있음
+extension ListExtensions<T> on List<T> {
+  List<E> mapIndexed<E>(E Function(T item, int index) f) {
+    List<E> result = [];
+    for (int i = 0; i < length; i++) {
+      result.add(f(this[i], i));
+    }
+    return result;
+  }
+}

--- a/lib/presentation/views/reservation/bloc/reservation_bloc.dart
+++ b/lib/presentation/views/reservation/bloc/reservation_bloc.dart
@@ -24,6 +24,12 @@ class ReservationBloc extends Bloc<ReservationEvent, ReservationState> {
     on<ReservationSelectedSeatsEvent>(
       (event, emit) => _setSelectedSeatList(event, emit),
     );
+    on<ReservationInputRealUserCountAddEvent>(
+      (event, emit) => _setInputRealUserCountAdd(event, emit),
+    );
+    on<ReservationInputRealUserCountMinusEvent>(
+      (event, emit) => _setInputRealUserCountMinus(event, emit),
+    );
   }
 
   void _setProcessCurrentPosition(
@@ -52,6 +58,14 @@ class ReservationBloc extends Bloc<ReservationEvent, ReservationState> {
     Emitter<ReservationState> emit,
   ) {
     emit(state.copyWith(selectedCount: event.reservationCount));
+
+    if (event.reservationCount == 0) {
+      emit(state.copyWith(realUserCount: 1));
+    } else if (event.reservationCount == 1) {
+      emit(state.copyWith(realUserCount: 4));
+    } else if (event.reservationCount == 2) {
+      emit(state.copyWith(realUserCount: 6));
+    }
   }
 
   void _setSelectedSeatList(
@@ -59,5 +73,43 @@ class ReservationBloc extends Bloc<ReservationEvent, ReservationState> {
     Emitter<ReservationState> emit,
   ) {
     emit(state.copyWith(selectedSeats: event.selectedSeatList));
+  }
+
+  void _setInputRealUserCountAdd(
+    ReservationInputRealUserCountAddEvent event,
+    Emitter<ReservationState> emit,
+  ) {
+    if (state.selectedCount == 0 && state.realUserCount == 3) {
+      return;
+    }
+
+    if (state.selectedCount == 1 && state.realUserCount == 5) {
+      return;
+    }
+
+    if (state.selectedCount == 2 && state.realUserCount == 8) {
+      return;
+    }
+
+    emit(state.copyWith(realUserCount: state.realUserCount + 1));
+  }
+
+  void _setInputRealUserCountMinus(
+    ReservationInputRealUserCountMinusEvent event,
+    Emitter<ReservationState> emit,
+  ) {
+    if (state.selectedCount == 0 && state.realUserCount == 1) {
+      return;
+    }
+
+    if (state.selectedCount == 1 && state.realUserCount == 4) {
+      return;
+    }
+
+    if (state.selectedCount == 2 && state.realUserCount == 6) {
+      return;
+    }
+
+    emit(state.copyWith(realUserCount: state.realUserCount - 1));
   }
 }

--- a/lib/presentation/views/reservation/bloc/reservation_bloc.dart
+++ b/lib/presentation/views/reservation/bloc/reservation_bloc.dart
@@ -21,6 +21,9 @@ class ReservationBloc extends Bloc<ReservationEvent, ReservationState> {
     on<ReservationSelectedCountEvent>(
       (event, emit) => _setSelectedCount(event, emit),
     );
+    on<ReservationSelectedSeatsEvent>(
+      (event, emit) => _setSelectedSeatList(event, emit),
+    );
   }
 
   void _setProcessCurrentPosition(
@@ -49,5 +52,12 @@ class ReservationBloc extends Bloc<ReservationEvent, ReservationState> {
     Emitter<ReservationState> emit,
   ) {
     emit(state.copyWith(selectedCount: event.reservationCount));
+  }
+
+  void _setSelectedSeatList(
+    ReservationSelectedSeatsEvent event,
+    Emitter<ReservationState> emit,
+  ) {
+    emit(state.copyWith(selectedSeats: event.selectedSeatList));
   }
 }

--- a/lib/presentation/views/reservation/bloc/reservation_bloc.dart
+++ b/lib/presentation/views/reservation/bloc/reservation_bloc.dart
@@ -6,6 +6,7 @@ part 'reservation_event.dart';
 
 part 'reservation_state.dart';
 
+// 📌 예약정보에 관한 State 를 관리하는 Bloc
 class ReservationBloc extends Bloc<ReservationEvent, ReservationState> {
   ReservationBloc() : super(ReservationState.initial()) {
     on<ReservationProcessEvent>(

--- a/lib/presentation/views/reservation/bloc/reservation_bloc.dart
+++ b/lib/presentation/views/reservation/bloc/reservation_bloc.dart
@@ -1,12 +1,13 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reservation_app/domain/model/seat/enum/seat_type.dart';
 
 part 'reservation_event.dart';
 
 part 'reservation_state.dart';
 
 class ReservationBloc extends Bloc<ReservationEvent, ReservationState> {
-  ReservationBloc() : super(ReservationProcessState.initial()) {
+  ReservationBloc() : super(ReservationState.initial()) {
     on<ReservationProcessEvent>(
       (event, emit) => _setProcessCurrentPosition(event, emit),
     );
@@ -25,50 +26,27 @@ class ReservationBloc extends Bloc<ReservationEvent, ReservationState> {
     ReservationProcessEvent event,
     Emitter<ReservationState> emit,
   ) {
-
-    if (state is ReservationProcessState) {
-      emit(
-        (state as ReservationProcessState).copyWith(currentPosition: event.processIndex),
-      );
-    }
+    emit(state.copyWith(currentPosition: event.processIndex));
   }
 
   void _setSelectedDate(
     ReservationDatePickerEvent event,
     Emitter<ReservationState> emit,
   ) {
-    if (state is ReservationProcessState) {
-      emit(
-        (state as ReservationProcessState).copyWith(
-          dateTime: event.selectedDateTime,
-        ),
-      );
-    }
+    emit(state.copyWith(dateTime: event.selectedDateTime));
   }
 
   void _setSelectedTime(
     ReservationRadioTimeSelectEvent event,
     Emitter<ReservationState> emit,
   ) {
-    if (state is ReservationProcessState) {
-      emit(
-        (state as ReservationProcessState).copyWith(
-          selectedTime: event.selectedTime,
-        ),
-      );
-    }
+    emit(state.copyWith(selectedTime: event.selectedTime));
   }
 
   void _setSelectedCount(
     ReservationSelectedCountEvent event,
     Emitter<ReservationState> emit,
   ) {
-    if (state is ReservationProcessState) {
-      emit(
-        (state as ReservationProcessState).copyWith(
-          selectedCount: event.reservationCount,
-        ),
-      );
-    }
+    emit(state.copyWith(selectedCount: event.reservationCount));
   }
 }

--- a/lib/presentation/views/reservation/bloc/reservation_event.dart
+++ b/lib/presentation/views/reservation/bloc/reservation_event.dart
@@ -63,3 +63,25 @@ class ReservationSelectedSeatsEvent extends ReservationEvent {
   @override
   bool? get stringify => false;
 }
+
+// 📌 실제 예약 인원수 Add Event
+class ReservationInputRealUserCountAddEvent extends ReservationEvent {
+  const ReservationInputRealUserCountAddEvent();
+
+  @override
+  List<Object?> get props => [];
+
+  @override
+  bool? get stringify => false;
+}
+
+// 📌 실제 예약 인원수 Minus Event
+class ReservationInputRealUserCountMinusEvent extends ReservationEvent {
+  const ReservationInputRealUserCountMinusEvent();
+
+  @override
+  List<Object?> get props => [];
+
+  @override
+  bool? get stringify => false;
+}

--- a/lib/presentation/views/reservation/bloc/reservation_event.dart
+++ b/lib/presentation/views/reservation/bloc/reservation_event.dart
@@ -51,3 +51,15 @@ class ReservationSelectedCountEvent extends ReservationEvent {
   @override
   bool? get stringify => false;
 }
+
+// 📌 좌석 선택 Event
+class ReservationSelectedSeatsEvent extends ReservationEvent {
+  final List<SeatType> selectedSeatList;
+  const ReservationSelectedSeatsEvent({required this.selectedSeatList});
+
+  @override
+  List<Object?> get props => [selectedSeatList];
+
+  @override
+  bool? get stringify => false;
+}

--- a/lib/presentation/views/reservation/bloc/reservation_state.dart
+++ b/lib/presentation/views/reservation/bloc/reservation_state.dart
@@ -1,57 +1,55 @@
 part of 'reservation_bloc.dart';
 
-abstract class ReservationState extends Equatable {
-  final int currentPosition;
-  const ReservationState({this.currentPosition = 0});
-}
+class ReservationState extends Equatable {
+  final int currentPosition; // 현재 Process Position
+  final DateTime? dateTime; // 선택된 날짜
+  final int selectedTime; // 선택된 시간 (PartTime)
+  final int selectedCount; // 선택된 예약인원수
+  final List<SeatType> selectedSeats; // 선택된 좌석 List
 
-class ReservationInitial extends ReservationState {
-  const ReservationInitial();
-
-  @override
-  List<Object> get props => [];
-}
-
-class ReservationProcessState extends ReservationState {
-  final DateTime? dateTime;
-  final int selectedTime;
-  final int selectedCount;
-
-  const ReservationProcessState({
-    super.currentPosition,
+  const ReservationState({
+    required this.currentPosition,
     this.dateTime,
     required this.selectedTime,
     required this.selectedCount,
+    required this.selectedSeats,
   });
 
-  factory ReservationProcessState.initial() {
-    return ReservationProcessState(
+  factory ReservationState.initial() {
+    return ReservationState(
       currentPosition: 0,
       dateTime: null,
       selectedTime: 0,
       selectedCount: 0,
+      selectedSeats: [],
     );
   }
 
-  ReservationProcessState copyWith({
+  ReservationState copyWith({
     int? currentPosition,
     DateTime? dateTime,
     int? selectedTime,
     int? selectedCount,
-}) {
-    return ReservationProcessState(
+    List<SeatType>? selectedSeats,
+  }) {
+    return ReservationState(
       currentPosition: currentPosition ?? this.currentPosition,
       dateTime: dateTime ?? this.dateTime,
       selectedTime: selectedTime ?? this.selectedTime,
       selectedCount: selectedCount ?? this.selectedCount,
+      selectedSeats: selectedSeats ?? this.selectedSeats,
     );
   }
 
   @override
   List<Object?> get props => [
-    currentPosition,
-    dateTime,
-    selectedTime,
-    selectedCount,
-  ];
+        currentPosition,
+        dateTime,
+        selectedTime,
+        selectedCount,
+        selectedSeats,
+      ];
+
+  @override
+  bool? get stringify => true;
 }

--- a/lib/presentation/views/reservation/bloc/reservation_state.dart
+++ b/lib/presentation/views/reservation/bloc/reservation_state.dart
@@ -4,8 +4,9 @@ class ReservationState extends Equatable {
   final int currentPosition; // 현재 Process Position
   final DateTime? dateTime; // 선택된 날짜
   final int selectedTime; // 선택된 시간 (PartTime)
-  final int selectedCount; // 선택된 예약인원수
+  final int selectedCount; // 선택된 예약인원수 [범위]
   final List<SeatType> selectedSeats; // 선택된 좌석 List
+  final int realUserCount; // 선택된 예약인원수 [실제 예약인원수]
 
   const ReservationState({
     required this.currentPosition,
@@ -13,6 +14,7 @@ class ReservationState extends Equatable {
     required this.selectedTime,
     required this.selectedCount,
     required this.selectedSeats,
+    required this.realUserCount,
   });
 
   factory ReservationState.initial() {
@@ -22,6 +24,7 @@ class ReservationState extends Equatable {
       selectedTime: 0,
       selectedCount: 0,
       selectedSeats: [],
+      realUserCount: 1,
     );
   }
 
@@ -31,6 +34,7 @@ class ReservationState extends Equatable {
     int? selectedTime,
     int? selectedCount,
     List<SeatType>? selectedSeats,
+    int? realUserCount,
   }) {
     return ReservationState(
       currentPosition: currentPosition ?? this.currentPosition,
@@ -38,6 +42,7 @@ class ReservationState extends Equatable {
       selectedTime: selectedTime ?? this.selectedTime,
       selectedCount: selectedCount ?? this.selectedCount,
       selectedSeats: selectedSeats ?? this.selectedSeats,
+      realUserCount: realUserCount ?? this.realUserCount,
     );
   }
 
@@ -48,6 +53,7 @@ class ReservationState extends Equatable {
         selectedTime,
         selectedCount,
         selectedSeats,
+        realUserCount,
       ];
 
   @override

--- a/lib/presentation/views/reservation/bloc/second/reservation_second_bloc.dart
+++ b/lib/presentation/views/reservation/bloc/second/reservation_second_bloc.dart
@@ -1,0 +1,88 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reservation_app/domain/model/base/data_state.dart';
+import 'package:reservation_app/domain/model/reservation/enum/part_time.dart';
+import 'package:reservation_app/domain/model/reservation/reservation_target_part_time_seat_model.dart';
+import 'package:reservation_app/domain/usecase/reservation/get_reservation_target_part_time_use_case.dart';
+import 'package:reservation_app/presentation/utils/constants.dart';
+
+part 'reservation_second_event.dart';
+
+part 'reservation_second_state.dart';
+
+class ReservationSecondBloc
+    extends Bloc<ReservationSecondEvent, ReservationSecondState> {
+  final GetReservationTargetPartTimeUseCase getReservationTargetPartTimeUseCase;
+
+  ReservationSecondBloc(this.getReservationTargetPartTimeUseCase)
+      : super(ReservationSecondInitial()) {
+    on<ReservationSecondEventGetSeatList>(
+      (event, emit) => _getRemainSeatList(
+        event,
+        emit,
+      ),
+    );
+  }
+
+  void _getRemainSeatList(
+    ReservationSecondEventGetSeatList event,
+    Emitter<ReservationSecondState> emit,
+  ) async {
+    emit(const ReservationSecondStateLoading());
+
+    final selectedTime = event.date;
+    if (selectedTime == null) {
+      emit(ReservationSecondStateNoSelectedDateTime());
+      return;
+    }
+
+    final response = await getReservationTargetPartTimeUseCase.invoke(
+      _numberToPartTime(selectedTime: event.partTime),
+      selectedTime,
+      _countToReservationCount(count: event.count),
+    );
+
+    if (response is DataSuccess) {
+      debugPrint(
+        "🌹 ReservationSecondBloc Success Data 👉 ${response.data ?? []}",
+      );
+      emit(ReservationSecondStateSeatList(seatLists: response.data ?? []));
+    } else if (response is DataError) {
+      debugPrint(
+        "🌹 ReservationSecondBloc DataError message 👉 ${response.error?.message}",
+      );
+      emit(ReservationSecondStateFailed(message: Constants.dataError));
+    } else if (response is DataNetworkError) {
+      debugPrint(
+        "🌹 ReservationSecondBloc NetworkError message 👉 ${response.error?.message}",
+      );
+      emit(ReservationSecondStateFailed(message: Constants.networkError));
+    } else {
+      debugPrint(
+        "🌹 ReservationSecondBloc DataError message 👉 ${response.error?.message}",
+      );
+      emit(ReservationSecondStateFailed(message: Constants.dataError));
+    }
+  }
+
+  PartTime _numberToPartTime({required int selectedTime}) {
+    return selectedTime == 0
+        ? PartTime.partA
+        : selectedTime == 1
+            ? PartTime.partB
+            : selectedTime == 2
+                ? PartTime.partC
+                : PartTime.partA;
+  }
+
+  int _countToReservationCount({required int count}) {
+    return count == 0
+        ? 3
+        : count == 1
+            ? 4
+            : count == 2
+                ? 6
+                : 3;
+  }
+}

--- a/lib/presentation/views/reservation/bloc/second/reservation_second_bloc.dart
+++ b/lib/presentation/views/reservation/bloc/second/reservation_second_bloc.dart
@@ -46,7 +46,10 @@ class ReservationSecondBloc
     final response = await getReservationTargetPartTimeUseCase.invoke(
       _numberToPartTime(selectedTime: event.partTime),
       selectedTime,
-      _countToReservationCount(count: event.count),
+      _countToReservationCount(
+        count: event.count,
+        maxUserCount: event.maxUserCount,
+      ),
     );
 
     if (response is DataSuccess) {
@@ -79,7 +82,8 @@ class ReservationSecondBloc
     final state = this.state;
     if (state is ReservationSecondStateSeatList) {
       List<ReservationTargetPartTimeSeatModel> seatLists = state.seatLists;
-      final currentSelectedList = state.seatLists.where((item) => item.isSelected).toList();
+      final currentSelectedList =
+          state.seatLists.where((item) => item.isSelected).toList();
 
       /// 📌 Item 최대 선택 수 설정
       /// Item 이 최대 선택 수를 초과하면 이전의 선택된 데이터들은 전부 비선택으로 바꾸고,
@@ -94,7 +98,8 @@ class ReservationSecondBloc
         }).toList();
       }
 
-      final List<ReservationTargetPartTimeSeatModel> newSeatLists = seatLists.toList();
+      final List<ReservationTargetPartTimeSeatModel> newSeatLists =
+          seatLists.toList();
 
       final updatedSeatList = seatLists[event.currentItem].copyWith(
         isSelected: !seatLists[event.currentItem].isSelected,
@@ -116,9 +121,10 @@ class ReservationSecondBloc
                 : PartTime.partA;
   }
 
-  int _countToReservationCount({required int count}) {
+  int _countToReservationCount(
+      {required int count, required int maxUserCount}) {
     return count == 0
-        ? 3
+        ? maxUserCount
         : count == 1
             ? 4
             : count == 2

--- a/lib/presentation/views/reservation/bloc/second/reservation_second_bloc.dart
+++ b/lib/presentation/views/reservation/bloc/second/reservation_second_bloc.dart
@@ -23,6 +23,12 @@ class ReservationSecondBloc
         emit,
       ),
     );
+    on<ReservationSecondEventSelectedSeats>(
+      (event, emit) => _selectedRemainSeatList(
+        event,
+        emit,
+      ),
+    );
   }
 
   void _getRemainSeatList(
@@ -63,6 +69,40 @@ class ReservationSecondBloc
         "🌹 ReservationSecondBloc DataError message 👉 ${response.error?.message}",
       );
       emit(ReservationSecondStateFailed(message: Constants.dataError));
+    }
+  }
+
+  void _selectedRemainSeatList(
+    ReservationSecondEventSelectedSeats event,
+    Emitter<ReservationSecondState> emit,
+  ) {
+    final state = this.state;
+    if (state is ReservationSecondStateSeatList) {
+      List<ReservationTargetPartTimeSeatModel> seatLists = state.seatLists;
+      final currentSelectedList = state.seatLists.where((item) => item.isSelected).toList();
+
+      /// 📌 Item 최대 선택 수 설정
+      /// Item 이 최대 선택 수를 초과하면 이전의 선택된 데이터들은 전부 비선택으로 바꾸고,
+      /// 현재 선택한 Item 만 선택으로 설정
+      if (currentSelectedList.length == event.selectedLimitUserCount) {
+        seatLists = seatLists.map((seat) {
+          if (seat.isSelected) {
+            return seat.copyWith(isSelected: false);
+          } else {
+            return seat;
+          }
+        }).toList();
+      }
+
+      final List<ReservationTargetPartTimeSeatModel> newSeatLists = seatLists.toList();
+
+      final updatedSeatList = seatLists[event.currentItem].copyWith(
+        isSelected: !seatLists[event.currentItem].isSelected,
+      );
+
+      newSeatLists[event.currentItem] = updatedSeatList;
+
+      emit(ReservationSecondStateSeatList(seatLists: newSeatLists));
     }
   }
 

--- a/lib/presentation/views/reservation/bloc/second/reservation_second_event.dart
+++ b/lib/presentation/views/reservation/bloc/second/reservation_second_event.dart
@@ -8,15 +8,17 @@ class ReservationSecondEventGetSeatList extends ReservationSecondEvent {
   final int partTime;
   final DateTime? date;
   final int count;
+  final int maxUserCount;
 
   const ReservationSecondEventGetSeatList({
     required this.partTime,
     required this.date,
     required this.count,
+    required this.maxUserCount,
   });
 
   @override
-  List<Object?> get props => [partTime, date, count];
+  List<Object?> get props => [partTime, date, count, maxUserCount];
 }
 
 class ReservationSecondEventSelectedSeats extends ReservationSecondEvent {

--- a/lib/presentation/views/reservation/bloc/second/reservation_second_event.dart
+++ b/lib/presentation/views/reservation/bloc/second/reservation_second_event.dart
@@ -1,0 +1,21 @@
+part of 'reservation_second_bloc.dart';
+
+abstract class ReservationSecondEvent extends Equatable {
+  const ReservationSecondEvent();
+}
+
+class ReservationSecondEventGetSeatList extends ReservationSecondEvent {
+  final int partTime;
+  final DateTime? date;
+  final int count;
+
+  const ReservationSecondEventGetSeatList({
+    required this.partTime,
+    required this.date,
+    required this.count,
+  });
+
+  @override
+  List<Object?> get props => [partTime, date, count];
+}
+

--- a/lib/presentation/views/reservation/bloc/second/reservation_second_event.dart
+++ b/lib/presentation/views/reservation/bloc/second/reservation_second_event.dart
@@ -19,3 +19,15 @@ class ReservationSecondEventGetSeatList extends ReservationSecondEvent {
   List<Object?> get props => [partTime, date, count];
 }
 
+class ReservationSecondEventSelectedSeats extends ReservationSecondEvent {
+  final int currentItem;
+  final int selectedLimitUserCount;
+
+  const ReservationSecondEventSelectedSeats({
+    required this.currentItem,
+    required this.selectedLimitUserCount,
+  });
+
+  @override
+  List<Object?> get props => [currentItem, selectedLimitUserCount];
+}

--- a/lib/presentation/views/reservation/bloc/second/reservation_second_state.dart
+++ b/lib/presentation/views/reservation/bloc/second/reservation_second_state.dart
@@ -1,0 +1,45 @@
+part of 'reservation_second_bloc.dart';
+
+abstract class ReservationSecondState extends Equatable {
+  const ReservationSecondState();
+}
+
+class ReservationSecondInitial extends ReservationSecondState {
+  const ReservationSecondInitial();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class ReservationSecondStateLoading extends ReservationSecondState {
+  const ReservationSecondStateLoading();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class ReservationSecondStateSeatList extends ReservationSecondState {
+  final List<ReservationTargetPartTimeSeatModel> seatLists;
+
+  const ReservationSecondStateSeatList({required this.seatLists});
+
+  @override
+  List<Object?> get props => [seatLists];
+}
+
+class ReservationSecondStateFailed extends ReservationSecondState {
+  final String message;
+
+  const ReservationSecondStateFailed({required this.message});
+
+  @override
+  List<Object?> get props => [message];
+}
+
+class ReservationSecondStateNoSelectedDateTime extends ReservationSecondState {
+  const ReservationSecondStateNoSelectedDateTime();
+
+  @override
+  List<Object?> get props => [];
+}
+

--- a/lib/presentation/views/reservation/bloc/second/reservation_second_state.dart
+++ b/lib/presentation/views/reservation/bloc/second/reservation_second_state.dart
@@ -25,6 +25,9 @@ class ReservationSecondStateSeatList extends ReservationSecondState {
 
   @override
   List<Object?> get props => [seatLists];
+
+  @override
+  bool? get stringify => true;
 }
 
 class ReservationSecondStateFailed extends ReservationSecondState {

--- a/lib/presentation/views/reservation/reservation_screen.dart
+++ b/lib/presentation/views/reservation/reservation_screen.dart
@@ -43,7 +43,7 @@ class _ReservationScreenState extends State<ReservationScreen> {
       child: Scaffold(
         backgroundColor: Colors.white,
         appBar: ReservationAppBarWidget(),
-        body: ReservationProcessView(),
+        body: SafeArea(child: ReservationProcessView(),),
         floatingActionButton: CloseFloatingActionWidget(),
       ),
     );

--- a/lib/presentation/views/reservation/reservation_screen.dart
+++ b/lib/presentation/views/reservation/reservation_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reservation_app/di/dependency_inection_graph.dart';
 import 'package:reservation_app/presentation/utils/color_constants.dart';
 import 'package:reservation_app/presentation/views/reservation/bloc/reservation_bloc.dart';
+import 'package:reservation_app/presentation/views/reservation/bloc/second/reservation_second_bloc.dart';
 import 'package:reservation_app/presentation/views/reservation/view/reservation_process_view.dart';
 import 'package:reservation_app/presentation/views/reservation/widget/reservation_app_bar_widget.dart';
 
@@ -30,8 +31,15 @@ class _ReservationScreenState extends State<ReservationScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider(
-      create: (context) => locator.get<ReservationBloc>(),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<ReservationBloc>(
+          create: (context) => locator.get<ReservationBloc>(),
+        ),
+        BlocProvider<ReservationSecondBloc>(
+          create: (context) => locator.get<ReservationSecondBloc>(),
+        ),
+      ],
       child: Scaffold(
         backgroundColor: Colors.white,
         appBar: ReservationAppBarWidget(),

--- a/lib/presentation/views/reservation/utils/reservation_utils.dart
+++ b/lib/presentation/views/reservation/utils/reservation_utils.dart
@@ -1,0 +1,36 @@
+import 'package:reservation_app/domain/model/reservation/reservation_target_part_time_seat_model.dart';
+import 'package:reservation_app/domain/model/seat/enum/seat_type.dart';
+
+class ReservationUtils {
+  static String partTimeToString({required int partTime}) {
+    if (partTime == 0) {
+      return "오후 1:00";
+    } else if (partTime == 1) {
+      return "오후 5:50";
+    } else if (partTime == 2) {
+      return "오후 8:00";
+    } else {
+      return "오후 1:00";
+    }
+  }
+
+  static String reservationCountToString({required int count}) {
+    if (count == 0) {
+      return "여기는 좀 있다가..";
+    } else if (count == 1) {
+      return "4 인석";
+    } else if (count == 2) {
+      return "6 인석";
+    } else {
+      return "여기는 좀 있다가..";
+    }
+  }
+
+  static List<SeatType> modelToSeatTypeList({
+    required List<ReservationTargetPartTimeSeatModel> selectedSeatList,
+  }) {
+    return selectedSeatList
+        .map((reservation) => reservation.remainSeatList)
+        .toList();
+  }
+}

--- a/lib/presentation/views/reservation/utils/reservation_utils.dart
+++ b/lib/presentation/views/reservation/utils/reservation_utils.dart
@@ -14,13 +14,15 @@ class ReservationUtils {
     }
   }
 
-  static String reservationCountToString({required int count}) {
+  static String reservationCountToString({
+    required int count, required int realUserCount
+  }) {
     if (count == 0) {
-      return "여기는 좀 있다가..";
+      return "1 인석 $realUserCount명";
     } else if (count == 1) {
-      return "4 인석";
+      return "4 인석 $realUserCount명";
     } else if (count == 2) {
-      return "6 인석";
+      return "6 인석 $realUserCount명";
     } else {
       return "여기는 좀 있다가..";
     }

--- a/lib/presentation/views/reservation/view/reservation_first_process_view.dart
+++ b/lib/presentation/views/reservation/view/reservation_first_process_view.dart
@@ -14,6 +14,28 @@ class ReservationFirstProcessView extends StatefulWidget {
 
 class _ReservationFirstProcessViewState
     extends State<ReservationFirstProcessView> {
+  late final ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void scrollToBottom() {
+    _scrollController.animateTo(
+      _scrollController.position.maxScrollExtent,
+      duration: Duration(milliseconds: 500), // 스크롤 애니메이션 소요 시간
+      curve: Curves.easeOut, // 스크롤 애니메이션 효과
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Expanded(
@@ -21,6 +43,7 @@ class _ReservationFirstProcessViewState
         margin: EdgeInsets.all(15.0),
         width: double.infinity,
         child: ListView(
+          controller: _scrollController,
           children: [
             Text(
               '예약 날짜/시간 선택',
@@ -61,7 +84,11 @@ class _ReservationFirstProcessViewState
             Container(
               constraints: const BoxConstraints.expand(height: 10.0),
             ),
-            ReservationSelectCountWidget(), // 예약 인원 수 선택
+            ReservationSelectCountWidget(
+              onScrollBottom: () {
+                scrollToBottom();
+              },
+            ),
           ],
         ),
       ),

--- a/lib/presentation/views/reservation/view/reservation_second_process_view.dart
+++ b/lib/presentation/views/reservation/view/reservation_second_process_view.dart
@@ -95,7 +95,7 @@ class _ReservationSecondProcessViewState
                                   ),
                                   Text(
                                     "${DateTimeUtils.dateTimeToString(
-                                      pattern: "yyyy-MM-dd",
+                                      pattern: "yyyy년 MM월 dd일",
                                       date: reservationBloc.state.dateTime!,
                                     )} ${DateTimeUtils.dateTimeToWeekDay(
                                       date: reservationBloc.state.dateTime!,
@@ -210,11 +210,14 @@ class _ReservationSecondProcessViewState
                                     children: [
                                       ElevatedButton(
                                         onPressed: () {
-                                          if (reservationBloc.state.selectedCount > 0) {
+                                          if (reservationBloc
+                                                  .state.selectedCount >
+                                              0) {
                                             reservationBloc.add(
                                               ReservationSelectedSeatsEvent(
-                                                selectedSeatList: ReservationUtils
-                                                    .modelToSeatTypeList(
+                                                selectedSeatList:
+                                                    ReservationUtils
+                                                        .modelToSeatTypeList(
                                                   selectedSeatList: seatList,
                                                 ),
                                               ),
@@ -288,6 +291,244 @@ class _ReservationSecondProcessViewState
                                   )
                                 ],
                               ),
+                            ),
+                          ),
+                          Container(
+                            margin: EdgeInsets.only(top: 20),
+                            padding: EdgeInsets.only(
+                              top: 20,
+                              left: 20,
+                              bottom: 20,
+                              right: 10,
+                            ),
+                            decoration: BoxDecoration(
+                              color: ColorsConstants.guideBackground,
+                              borderRadius: BorderRadius.circular(15),
+                            ),
+                            child: Column(
+                              children: [
+                                Row(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Container(
+                                      margin: EdgeInsets.only(right: 7, top: 7),
+                                      width: 2,
+                                      height: 2,
+                                      color: ColorsConstants.guideText,
+                                    ),
+                                    Flexible(
+                                      child: RichText(
+                                        text: TextSpan(
+                                          children: [
+                                            TextSpan(
+                                              text: '입력하신 예약 정보가 맞다면',
+                                              style: TextStyle(
+                                                fontSize: 12,
+                                                color:
+                                                    ColorsConstants.guideText,
+                                                letterSpacing: -0.02,
+                                              ),
+                                            ),
+                                            TextSpan(
+                                              text: ' 해당 날짜로 예약 ',
+                                              style: TextStyle(
+                                                fontSize: 12,
+                                                color:
+                                                    ColorsConstants.guideText,
+                                                letterSpacing: -0.02,
+                                                fontWeight: FontWeight.w600,
+                                              ),
+                                            ),
+                                            TextSpan(
+                                              text: '버튼을 눌러주세요.',
+                                              style: TextStyle(
+                                                fontSize: 12,
+                                                color:
+                                                    ColorsConstants.guideText,
+                                                letterSpacing: -0.02,
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                Container(
+                                  constraints:
+                                      const BoxConstraints.expand(height: 5),
+                                ),
+                                Row(
+                                  crossAxisAlignment: CrossAxisAlignment.center,
+                                  children: [
+                                    Container(
+                                      margin: EdgeInsets.only(right: 7),
+                                      width: 2,
+                                      height: 2,
+                                      color: ColorsConstants.guideText,
+                                    ),
+                                    Flexible(
+                                      child: RichText(
+                                        text: TextSpan(
+                                          children: [
+                                            TextSpan(
+                                              text: '예약 정보를 변경 하시려면',
+                                              style: TextStyle(
+                                                fontSize: 12,
+                                                color:
+                                                    ColorsConstants.guideText,
+                                                letterSpacing: -0.02,
+                                              ),
+                                            ),
+                                            TextSpan(
+                                              text: ' 예약 정보 변경 ',
+                                              style: TextStyle(
+                                                fontSize: 12,
+                                                color:
+                                                    ColorsConstants.guideText,
+                                                letterSpacing: -0.02,
+                                                fontWeight: FontWeight.w600,
+                                              ),
+                                            ),
+                                            TextSpan(
+                                              text: '버튼을 눌러주세요.',
+                                              style: TextStyle(
+                                                fontSize: 12,
+                                                color:
+                                                    ColorsConstants.guideText,
+                                                letterSpacing: -0.02,
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                Container(
+                                  constraints:
+                                      const BoxConstraints.expand(height: 5),
+                                ),
+                                Row(
+                                  crossAxisAlignment: CrossAxisAlignment.center,
+                                  children: [
+                                    Container(
+                                      margin: EdgeInsets.only(right: 7),
+                                      width: 2,
+                                      height: 2,
+                                      color: ColorsConstants.guideText,
+                                    ),
+                                    Flexible(
+                                      child: RichText(
+                                        text: TextSpan(
+                                          children: [
+                                            TextSpan(
+                                              text: '1인석 ',
+                                              style: TextStyle(
+                                                fontSize: 12,
+                                                color:
+                                                    ColorsConstants.guideText,
+                                                letterSpacing: -0.02,
+                                                fontWeight: FontWeight.w600,
+                                              ),
+                                            ),
+                                            TextSpan(
+                                              text: '자리를 선택하신 경우',
+                                              style: TextStyle(
+                                                fontSize: 12,
+                                                color:
+                                                    ColorsConstants.guideText,
+                                                letterSpacing: -0.02,
+                                              ),
+                                            ),
+                                            TextSpan(
+                                              text: ' 죄석 선택',
+                                              style: TextStyle(
+                                                fontSize: 12,
+                                                color:
+                                                    ColorsConstants.guideText,
+                                                letterSpacing: -0.02,
+                                                fontWeight: FontWeight.w600,
+                                              ),
+                                            ),
+                                            TextSpan(
+                                              text: '이 가능합니다.',
+                                              style: TextStyle(
+                                                fontSize: 12,
+                                                color:
+                                                    ColorsConstants.guideText,
+                                                letterSpacing: -0.02,
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                Container(
+                                  constraints:
+                                      const BoxConstraints.expand(height: 5),
+                                ),
+                                Row(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Container(
+                                      margin: EdgeInsets.only(right: 7, top: 7),
+                                      width: 2,
+                                      height: 2,
+                                      color: ColorsConstants.guideText,
+                                    ),
+                                    Flexible(
+                                      child: RichText(
+                                        text: TextSpan(
+                                          children: [
+                                            TextSpan(
+                                              text: '4인석, 6인석 ',
+                                              style: TextStyle(
+                                                fontSize: 12,
+                                                color:
+                                                    ColorsConstants.guideText,
+                                                letterSpacing: -0.02,
+                                                fontWeight: FontWeight.w600,
+                                              ),
+                                            ),
+                                            TextSpan(
+                                              text: '자리를 선택하신 경우',
+                                              style: TextStyle(
+                                                fontSize: 12,
+                                                color:
+                                                    ColorsConstants.guideText,
+                                                letterSpacing: -0.02,
+                                              ),
+                                            ),
+                                            TextSpan(
+                                              text: ' 별도의 룸',
+                                              style: TextStyle(
+                                                fontSize: 12,
+                                                color:
+                                                    ColorsConstants.guideText,
+                                                letterSpacing: -0.02,
+                                                fontWeight: FontWeight.w600,
+                                              ),
+                                            ),
+                                            TextSpan(
+                                              text:
+                                                  '으로 되어있어 좌석 선택을 하실 필요가 없습니다.',
+                                              style: TextStyle(
+                                                fontSize: 12,
+                                                color:
+                                                    ColorsConstants.guideText,
+                                                letterSpacing: -0.02,
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ],
                             ),
                           ),
                         ],

--- a/lib/presentation/views/reservation/view/reservation_second_process_view.dart
+++ b/lib/presentation/views/reservation/view/reservation_second_process_view.dart
@@ -33,7 +33,7 @@ class _ReservationSecondProcessViewState
         count: reservationBloc.state.selectedCount,
       ));
 
-    void _onReservationCick(
+    void onReservationClick(
         {required List<ReservationTargetPartTimeSeatModel> seatList}) {
       if (reservationBloc.state.selectedCount > 0) {
         reservationBloc.add(
@@ -312,8 +312,9 @@ class _ReservationSecondProcessViewState
                                     children: [
                                       ElevatedButton(
                                         onPressed: () {
-                                          _onReservationCick(
-                                              seatList: seatList);
+                                          onReservationClick(
+                                            seatList: seatList,
+                                          );
                                         },
                                         style: ButtonStyle(
                                           shape: MaterialStateProperty.all<

--- a/lib/presentation/views/reservation/view/reservation_second_process_view.dart
+++ b/lib/presentation/views/reservation/view/reservation_second_process_view.dart
@@ -1,15 +1,27 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reservation_app/presentation/views/reservation/bloc/reservation_bloc.dart';
 
 class ReservationSecondProcessView extends StatefulWidget {
   const ReservationSecondProcessView({Key? key}) : super(key: key);
 
   @override
-  State<ReservationSecondProcessView> createState() => _ReservationSecondProcessViewState();
+  State<ReservationSecondProcessView> createState() =>
+      _ReservationSecondProcessViewState();
 }
 
-class _ReservationSecondProcessViewState extends State<ReservationSecondProcessView> {
+class _ReservationSecondProcessViewState
+    extends State<ReservationSecondProcessView> {
   @override
   Widget build(BuildContext context) {
-    return const Center(child: Text("좌석 선택"),);
+    return Expanded(
+      child: BlocBuilder<ReservationBloc, ReservationState>(
+        builder: (context, state) {
+          return Container(
+            child: Text("좌석선택"),
+          );
+        },
+      ),
+    );
   }
 }

--- a/lib/presentation/views/reservation/view/reservation_second_process_view.dart
+++ b/lib/presentation/views/reservation/view/reservation_second_process_view.dart
@@ -31,6 +31,7 @@ class _ReservationSecondProcessViewState
         partTime: reservationBloc.state.selectedTime,
         date: reservationBloc.state.dateTime,
         count: reservationBloc.state.selectedCount,
+        maxUserCount: reservationBloc.state.realUserCount,
       ));
 
     void onReservationClick(
@@ -124,104 +125,168 @@ class _ReservationSecondProcessViewState
                   bottom: 20.0,
                 ),
                 width: MediaQuery.of(context).size.width,
-                child: seatList.isEmpty
-                    ? SizedBox.expand()
-                    : ListView(
-                        children: [
-                          Container(
-                            padding: EdgeInsets.only(
-                              bottom: 15,
-                              left: 20,
-                              right: 20,
+                child: ListView(
+                  children: [
+                    Container(
+                      padding: EdgeInsets.only(
+                        bottom: 15,
+                        left: 20,
+                        right: 20,
+                      ),
+                      decoration: BoxDecoration(
+                        border: Border.all(
+                          color: seatList.isEmpty
+                              ? ColorsConstants.primary
+                              : ColorsConstants
+                                  .calendarPickerColor, // 테두리 색상 설정
+                          width: 2.0, // 테두리 너비 설정
+                        ),
+                        borderRadius: BorderRadius.circular(15),
+                      ),
+                      child: Center(
+                        child: Column(
+                          children: [
+                            Lottie.asset(
+                              seatList.isEmpty
+                                  ? 'assets/lottie/error-animation.json'
+                                  : 'assets/lottie/success_animation.json',
+                              animate: true,
+                              width: 100,
+                              height: 100,
+                              repeat: false,
                             ),
-                            decoration: BoxDecoration(
-                              border: Border.all(
-                                color: ColorsConstants
-                                    .calendarPickerColor, // 테두리 색상 설정
-                                width: 2.0, // 테두리 너비 설정
+                            Text(
+                              "선택하신 날짜",
+                              style: TextStyle(
+                                fontSize: 15,
+                                color: ColorsConstants.divider,
                               ),
-                              borderRadius: BorderRadius.circular(15),
                             ),
-                            child: Center(
-                              child: Column(
-                                children: [
-                                  Lottie.asset(
-                                    'assets/lottie/success_animation.json',
-                                    animate: true,
-                                    width: 100,
-                                    height: 100,
-                                    repeat: false,
+                            Text(
+                              "${DateTimeUtils.dateTimeToString(
+                                pattern: "yyyy년 MM월 dd일",
+                                date: reservationBloc.state.dateTime!,
+                              )} ${DateTimeUtils.dateTimeToWeekDay(
+                                date: reservationBloc.state.dateTime!,
+                              )}",
+                              style: TextStyle(
+                                fontSize: 16,
+                                color: ColorsConstants.strokeColor,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Text(
+                                  ReservationUtils.partTimeToString(
+                                    partTime:
+                                        reservationBloc.state.selectedTime,
                                   ),
-                                  Text(
-                                    "선택하신 날짜",
-                                    style: TextStyle(
-                                      fontSize: 15,
-                                      color: ColorsConstants.divider,
-                                    ),
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                    color: ColorsConstants.strokeColor,
+                                    fontWeight: FontWeight.bold,
                                   ),
-                                  Text(
-                                    "${DateTimeUtils.dateTimeToString(
-                                      pattern: "yyyy년 MM월 dd일",
-                                      date: reservationBloc.state.dateTime!,
-                                    )} ${DateTimeUtils.dateTimeToWeekDay(
-                                      date: reservationBloc.state.dateTime!,
-                                    )}",
-                                    style: TextStyle(
-                                      fontSize: 16,
-                                      color: ColorsConstants.strokeColor,
-                                      fontWeight: FontWeight.bold,
-                                    ),
+                                ),
+                                Text(
+                                  "시에",
+                                  style: TextStyle(
+                                    fontSize: 15,
+                                    color: ColorsConstants.divider,
                                   ),
-                                  Row(
-                                    mainAxisAlignment: MainAxisAlignment.center,
+                                ),
+                              ],
+                            ),
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Text(
+                                  ReservationUtils.reservationCountToString(
+                                    count: reservationBloc.state.selectedCount,
+                                    realUserCount:
+                                        reservationBloc.state.realUserCount,
+                                  ),
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                    color: ColorsConstants.strokeColor,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                                Text(
+                                  seatList.isEmpty ? "은" : "으로",
+                                  style: TextStyle(
+                                    fontSize: 15,
+                                    color: ColorsConstants.divider,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            seatList.isEmpty
+                                ? Column(
                                     children: [
-                                      Text(
-                                        ReservationUtils.partTimeToString(
-                                          partTime: reservationBloc
-                                              .state.selectedTime,
-                                        ),
-                                        style: TextStyle(
-                                          fontSize: 16,
-                                          color: ColorsConstants.strokeColor,
-                                          fontWeight: FontWeight.bold,
+                                      RichText(
+                                        text: TextSpan(
+                                          children: [
+                                            TextSpan(
+                                              text: '이미 예약이 ',
+                                              style: TextStyle(
+                                                fontSize: 15,
+                                                color: ColorsConstants.divider,
+                                              ),
+                                            ),
+                                            TextSpan(
+                                              text: '꽉 찼어요ㅠ',
+                                              style: TextStyle(
+                                                fontSize: 15,
+                                                color: ColorsConstants.primary,
+                                                fontWeight: FontWeight.bold,
+                                              ),
+                                            ),
+                                          ],
                                         ),
                                       ),
-                                      Text(
-                                        "시에",
-                                        style: TextStyle(
-                                          fontSize: 15,
-                                          color: ColorsConstants.divider,
+                                      RichText(
+                                        text: TextSpan(
+                                          children: [
+                                            TextSpan(
+                                              text: '다른 날짜',
+                                              style: TextStyle(
+                                                fontSize: 15,
+                                                color:
+                                                    ColorsConstants.strokeColor,
+                                                fontWeight: FontWeight.bold,
+                                              ),
+                                            ),
+                                            TextSpan(
+                                              text: '로 ',
+                                              style: TextStyle(
+                                                fontSize: 15,
+                                                color: ColorsConstants.divider,
+                                              ),
+                                            ),
+                                            TextSpan(
+                                              text: '변경',
+                                              style: TextStyle(
+                                                fontSize: 15,
+                                                color:
+                                                    ColorsConstants.strokeColor,
+                                                fontWeight: FontWeight.bold,
+                                              ),
+                                            ),
+                                            TextSpan(
+                                              text: '해주세요..!',
+                                              style: TextStyle(
+                                                fontSize: 15,
+                                                color: ColorsConstants.divider,
+                                              ),
+                                            ),
+                                          ],
                                         ),
                                       ),
                                     ],
-                                  ),
-                                  Row(
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    children: [
-                                      Text(
-                                        ReservationUtils
-                                            .reservationCountToString(
-                                          count: reservationBloc
-                                              .state.selectedCount,
-                                          realUserCount: reservationBloc
-                                              .state.realUserCount,
-                                        ),
-                                        style: TextStyle(
-                                          fontSize: 16,
-                                          color: ColorsConstants.strokeColor,
-                                          fontWeight: FontWeight.bold,
-                                        ),
-                                      ),
-                                      Text(
-                                        "으로",
-                                        style: TextStyle(
-                                          fontSize: 15,
-                                          color: ColorsConstants.divider,
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                  RichText(
+                                  )
+                                : RichText(
                                     text: TextSpan(
                                       children: [
                                         TextSpan(
@@ -257,7 +322,12 @@ class _ReservationSecondProcessViewState
                                       ],
                                     ),
                                   ),
-                                  Container(
+                            seatList.isEmpty
+                                ? Container(
+                                    constraints:
+                                        BoxConstraints.expand(height: 10),
+                                  )
+                                : Container(
                                     constraints: BoxConstraints.expand(
                                       height:
                                           reservationBloc.state.selectedCount ==
@@ -266,126 +336,121 @@ class _ReservationSecondProcessViewState
                                               : 30.0,
                                     ),
                                   ),
-                                  Visibility(
-                                    visible: reservationBloc
-                                                .state.selectedCount ==
-                                            0 &&
+                            if (seatList.isNotEmpty)
+                              Visibility(
+                                visible:
+                                    reservationBloc.state.selectedCount == 0 &&
                                         reservationBloc.state.realUserCount < 4,
-                                    child: RemainSeatListAdapter(
-                                      seatList: seatList,
-                                      onSelectedSeat: ({
-                                        required int selectedItem,
-                                      }) {
-                                        reservationSecondBloc.add(
-                                          ReservationSecondEventSelectedSeats(
-                                            currentItem: selectedItem,
-                                            selectedLimitUserCount:
-                                                reservationBloc
-                                                    .state.realUserCount,
-                                          ),
-                                        );
-                                      },
-                                    ),
-                                  ),
-                                  Container(
-                                    constraints: BoxConstraints.expand(
-                                      height:
-                                          reservationBloc.state.selectedCount ==
-                                                  0
-                                              ? 10
-                                              : 0,
-                                    ),
-                                  ),
-                                  Divider(
-                                    height: 1,
-                                    color: ColorsConstants.calendarPickerColor,
-                                  ),
-                                  Container(
-                                    constraints: const BoxConstraints.expand(
-                                      height: 10.0,
-                                    ),
-                                  ),
-                                  Row(
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.center,
-                                    children: [
-                                      ElevatedButton(
-                                        onPressed: () {
-                                          onReservationClick(
-                                            seatList: seatList,
-                                          );
-                                        },
-                                        style: ButtonStyle(
-                                          shape: MaterialStateProperty.all<
-                                              RoundedRectangleBorder>(
-                                            RoundedRectangleBorder(
-                                              borderRadius:
-                                                  BorderRadius.circular(
-                                                50.0,
-                                              ),
-                                            ),
-                                          ),
-                                          backgroundColor:
-                                              MaterialStateProperty.all<Color>(
-                                            ColorsConstants.strokeColor,
-                                          ),
-                                        ),
-                                        child: Text(
-                                          "해당 날짜로 예약",
-                                          style: TextStyle(
-                                            color: ColorsConstants.background,
-                                            fontSize: 14,
-                                            fontWeight: FontWeight.bold,
-                                          ),
-                                        ),
+                                child: RemainSeatListAdapter(
+                                  seatList: seatList,
+                                  onSelectedSeat: ({
+                                    required int selectedItem,
+                                  }) {
+                                    reservationSecondBloc.add(
+                                      ReservationSecondEventSelectedSeats(
+                                        currentItem: selectedItem,
+                                        selectedLimitUserCount:
+                                            reservationBloc.state.realUserCount,
                                       ),
-                                      SizedBox(width: 30),
-                                      ElevatedButton(
-                                        onPressed: () {
-                                          reservationBloc.add(
-                                            ReservationProcessEvent(
-                                              processIndex: (reservationBloc
-                                                          .state
-                                                          .currentPosition -
-                                                      1) %
-                                                  Constants
-                                                      .reservationProcessList
-                                                      .length,
-                                            ),
-                                          );
-                                        },
-                                        style: ButtonStyle(
-                                          shape: MaterialStateProperty.all<
-                                              RoundedRectangleBorder>(
-                                            RoundedRectangleBorder(
-                                              borderRadius:
-                                                  BorderRadius.circular(
-                                                50.0,
-                                              ),
-                                            ),
-                                          ),
-                                          backgroundColor:
-                                              MaterialStateProperty.all<Color>(
-                                            ColorsConstants.primary,
-                                          ),
-                                        ),
-                                        child: Text(
-                                          "예약 정보 변경",
-                                          style: TextStyle(
-                                            color: ColorsConstants.background,
-                                            fontSize: 14,
-                                            fontWeight: FontWeight.bold,
-                                          ),
-                                        ),
-                                      ),
-                                    ],
-                                  )
-                                ],
+                                    );
+                                  },
+                                ),
+                              ),
+                            Container(
+                              constraints: BoxConstraints.expand(
+                                height: reservationBloc.state.selectedCount == 0
+                                    ? 10
+                                    : 0,
                               ),
                             ),
-                          ),
-                          Container(
+                            Divider(
+                              height: 1,
+                              color: ColorsConstants.calendarPickerColor,
+                            ),
+                            Container(
+                              constraints: const BoxConstraints.expand(
+                                height: 10.0,
+                              ),
+                            ),
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              children: [
+                                if (seatList.isNotEmpty)
+                                  ElevatedButton(
+                                    onPressed: () {
+                                      onReservationClick(
+                                        seatList: seatList,
+                                      );
+                                    },
+                                    style: ButtonStyle(
+                                      shape: MaterialStateProperty.all<
+                                          RoundedRectangleBorder>(
+                                        RoundedRectangleBorder(
+                                          borderRadius: BorderRadius.circular(
+                                            50.0,
+                                          ),
+                                        ),
+                                      ),
+                                      backgroundColor:
+                                          MaterialStateProperty.all<Color>(
+                                        ColorsConstants.strokeColor,
+                                      ),
+                                    ),
+                                    child: Text(
+                                      "해당 날짜로 예약",
+                                      style: TextStyle(
+                                        color: ColorsConstants.background,
+                                        fontSize: 14,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                  ),
+                                if (seatList.isNotEmpty) SizedBox(width: 30),
+                                ElevatedButton(
+                                  onPressed: () {
+                                    reservationBloc.add(
+                                      ReservationProcessEvent(
+                                        processIndex: (reservationBloc
+                                                    .state.currentPosition -
+                                                1) %
+                                            Constants
+                                                .reservationProcessList.length,
+                                      ),
+                                    );
+                                  },
+                                  style: ButtonStyle(
+                                    shape: MaterialStateProperty.all<
+                                        RoundedRectangleBorder>(
+                                      RoundedRectangleBorder(
+                                        borderRadius: BorderRadius.circular(
+                                          50.0,
+                                        ),
+                                      ),
+                                    ),
+                                    backgroundColor:
+                                        MaterialStateProperty.all<Color>(
+                                      ColorsConstants.primary,
+                                    ),
+                                  ),
+                                  child: Text(
+                                    "예약 정보 변경",
+                                    style: TextStyle(
+                                      color: ColorsConstants.background,
+                                      fontSize: 14,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            )
+                          ],
+                        ),
+                      ),
+                    ),
+                    seatList.isEmpty
+                        ? SizedBox.expand()
+                        : Container(
                             margin: EdgeInsets.only(top: 20),
                             padding: EdgeInsets.only(
                               top: 20,
@@ -623,8 +688,8 @@ class _ReservationSecondProcessViewState
                               ],
                             ),
                           ),
-                        ],
-                      ),
+                  ],
+                ),
               );
 
             default:

--- a/lib/presentation/views/reservation/view/reservation_second_process_view.dart
+++ b/lib/presentation/views/reservation/view/reservation_second_process_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reservation_app/presentation/views/reservation/bloc/reservation_bloc.dart';
+import 'package:reservation_app/presentation/views/reservation/bloc/second/reservation_second_bloc.dart';
 
 class ReservationSecondProcessView extends StatefulWidget {
   const ReservationSecondProcessView({Key? key}) : super(key: key);
@@ -14,8 +15,18 @@ class _ReservationSecondProcessViewState
     extends State<ReservationSecondProcessView> {
   @override
   Widget build(BuildContext context) {
+    final reservationBloc = BlocProvider.of<ReservationBloc>(context);
+    final reservationSecondBloc =
+        BlocProvider.of<ReservationSecondBloc>(context)
+          ..add(ReservationSecondEventGetSeatList(
+            partTime: reservationBloc.state.selectedTime,
+            date: reservationBloc.state.dateTime,
+            count: reservationBloc.state.selectedCount,
+          ));
+
     return Expanded(
-      child: BlocBuilder<ReservationBloc, ReservationState>(
+      child: BlocBuilder<ReservationSecondBloc, ReservationSecondState>(
+        bloc: reservationSecondBloc,
         builder: (context, state) {
           return Container(
             child: Text("좌석선택"),

--- a/lib/presentation/views/reservation/view/reservation_second_process_view.dart
+++ b/lib/presentation/views/reservation/view/reservation_second_process_view.dart
@@ -1,7 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:lottie/lottie.dart';
+import 'package:reservation_app/domain/model/reservation/reservation_target_part_time_seat_model.dart';
+import 'package:reservation_app/presentation/utils/color_constants.dart';
+import 'package:reservation_app/presentation/utils/constants.dart';
+import 'package:reservation_app/presentation/utils/date_time_utils.dart';
+import 'package:reservation_app/presentation/views/common/network_error_widget.dart';
+import 'package:reservation_app/presentation/views/common/network_loading_widget.dart';
 import 'package:reservation_app/presentation/views/reservation/bloc/reservation_bloc.dart';
 import 'package:reservation_app/presentation/views/reservation/bloc/second/reservation_second_bloc.dart';
+import 'package:reservation_app/presentation/views/reservation/utils/reservation_utils.dart';
 
 class ReservationSecondProcessView extends StatefulWidget {
   const ReservationSecondProcessView({Key? key}) : super(key: key);
@@ -28,9 +36,269 @@ class _ReservationSecondProcessViewState
       child: BlocBuilder<ReservationSecondBloc, ReservationSecondState>(
         bloc: reservationSecondBloc,
         builder: (context, state) {
-          return Container(
-            child: Text("좌석선택"),
-          );
+          switch (state.runtimeType) {
+            case ReservationSecondStateLoading:
+              return const NetworkLoadingWidget();
+
+            case ReservationSecondStateFailed:
+              final errorMessage =
+                  (state as ReservationSecondStateFailed).message;
+              return NetworkErrorWidget(
+                errorMessage: errorMessage,
+              );
+
+            case ReservationSecondStateNoSelectedDateTime:
+              return const SizedBox();
+
+            case ReservationSecondStateSeatList:
+              final List<ReservationTargetPartTimeSeatModel> seatList =
+                  (state as ReservationSecondStateSeatList).seatLists;
+
+              return Container(
+                margin: EdgeInsets.only(
+                    top: 30.0, left: 20.0, right: 20.0, bottom: 20.0),
+                width: MediaQuery.of(context).size.width,
+                child: seatList.isEmpty
+                    ? SizedBox.expand()
+                    : ListView(
+                        children: [
+                          Container(
+                            padding: EdgeInsets.only(
+                              bottom: 15,
+                              left: 20,
+                              right: 20,
+                            ),
+                            decoration: BoxDecoration(
+                              border: Border.all(
+                                color: ColorsConstants
+                                    .calendarPickerColor, // 테두리 색상 설정
+                                width: 2.0, // 테두리 너비 설정
+                              ),
+                              borderRadius: BorderRadius.circular(15),
+                            ),
+                            child: Center(
+                              child: Column(
+                                children: [
+                                  Lottie.asset(
+                                    'assets/lottie/success_animation.json',
+                                    animate: true,
+                                    width: 100,
+                                    height: 100,
+                                    repeat: false,
+                                  ),
+                                  Text(
+                                    "선택하신 날짜",
+                                    style: TextStyle(
+                                      fontSize: 15,
+                                      color: ColorsConstants.divider,
+                                    ),
+                                  ),
+                                  Text(
+                                    "${DateTimeUtils.dateTimeToString(
+                                      pattern: "yyyy-MM-dd",
+                                      date: reservationBloc.state.dateTime!,
+                                    )} ${DateTimeUtils.dateTimeToWeekDay(
+                                      date: reservationBloc.state.dateTime!,
+                                    )}",
+                                    style: TextStyle(
+                                      fontSize: 16,
+                                      color: ColorsConstants.strokeColor,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                  Row(
+                                    mainAxisAlignment: MainAxisAlignment.center,
+                                    children: [
+                                      Text(
+                                        ReservationUtils.partTimeToString(
+                                          partTime: reservationBloc
+                                              .state.selectedTime,
+                                        ),
+                                        style: TextStyle(
+                                          fontSize: 16,
+                                          color: ColorsConstants.strokeColor,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                      Text(
+                                        "시에",
+                                        style: TextStyle(
+                                          fontSize: 15,
+                                          color: ColorsConstants.divider,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                  Row(
+                                    mainAxisAlignment: MainAxisAlignment.center,
+                                    children: [
+                                      Text(
+                                        ReservationUtils
+                                            .reservationCountToString(
+                                          count: reservationBloc
+                                              .state.selectedCount,
+                                        ),
+                                        style: TextStyle(
+                                          fontSize: 16,
+                                          color: ColorsConstants.strokeColor,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                      Text(
+                                        "으로",
+                                        style: TextStyle(
+                                          fontSize: 15,
+                                          color: ColorsConstants.divider,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                  RichText(
+                                    text: TextSpan(
+                                      children: [
+                                        TextSpan(
+                                          text: '예약',
+                                          style: TextStyle(
+                                            fontSize: 15,
+                                            color: ColorsConstants.divider,
+                                            fontWeight: FontWeight.w600,
+                                          ),
+                                        ),
+                                        TextSpan(
+                                          text: '이 ',
+                                          style: TextStyle(
+                                            fontSize: 15,
+                                            color: ColorsConstants.divider,
+                                          ),
+                                        ),
+                                        TextSpan(
+                                          text: '가능',
+                                          style: TextStyle(
+                                            fontSize: 15,
+                                            color: ColorsConstants.divider,
+                                            fontWeight: FontWeight.w600,
+                                          ),
+                                        ),
+                                        TextSpan(
+                                          text: '합니다!',
+                                          style: TextStyle(
+                                            fontSize: 15,
+                                            color: ColorsConstants.divider,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                  Container(
+                                    constraints: const BoxConstraints.expand(
+                                      height: 30.0,
+                                    ),
+                                  ),
+                                  Divider(
+                                    height: 1,
+                                    color: ColorsConstants.calendarPickerColor,
+                                  ),
+                                  Container(
+                                    constraints: const BoxConstraints.expand(
+                                      height: 10.0,
+                                    ),
+                                  ),
+                                  Row(
+                                    mainAxisAlignment: MainAxisAlignment.center,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.center,
+                                    children: [
+                                      ElevatedButton(
+                                        onPressed: () {
+                                          if (reservationBloc.state.selectedCount > 0) {
+                                            reservationBloc.add(
+                                              ReservationSelectedSeatsEvent(
+                                                selectedSeatList: ReservationUtils
+                                                    .modelToSeatTypeList(
+                                                  selectedSeatList: seatList,
+                                                ),
+                                              ),
+                                            );
+                                          }
+                                        },
+                                        style: ButtonStyle(
+                                          shape: MaterialStateProperty.all<
+                                              RoundedRectangleBorder>(
+                                            RoundedRectangleBorder(
+                                              borderRadius:
+                                                  BorderRadius.circular(
+                                                50.0,
+                                              ),
+                                            ),
+                                          ),
+                                          backgroundColor:
+                                              MaterialStateProperty.all<Color>(
+                                            ColorsConstants.strokeColor,
+                                          ),
+                                        ),
+                                        child: Text(
+                                          "해당 날짜로 예약",
+                                          style: TextStyle(
+                                            color: ColorsConstants.background,
+                                            fontSize: 14,
+                                            fontWeight: FontWeight.bold,
+                                          ),
+                                        ),
+                                      ),
+                                      SizedBox(width: 30),
+                                      ElevatedButton(
+                                        onPressed: () {
+                                          reservationBloc.add(
+                                            ReservationProcessEvent(
+                                              processIndex: (reservationBloc
+                                                          .state
+                                                          .currentPosition -
+                                                      1) %
+                                                  Constants
+                                                      .reservationProcessList
+                                                      .length,
+                                            ),
+                                          );
+                                        },
+                                        style: ButtonStyle(
+                                          shape: MaterialStateProperty.all<
+                                              RoundedRectangleBorder>(
+                                            RoundedRectangleBorder(
+                                              borderRadius:
+                                                  BorderRadius.circular(
+                                                50.0,
+                                              ),
+                                            ),
+                                          ),
+                                          backgroundColor:
+                                              MaterialStateProperty.all<Color>(
+                                            ColorsConstants.primary,
+                                          ),
+                                        ),
+                                        child: Text(
+                                          "예약 정보 변경",
+                                          style: TextStyle(
+                                            color: ColorsConstants.background,
+                                            fontSize: 14,
+                                            fontWeight: FontWeight.bold,
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                  )
+                                ],
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+              );
+
+            default:
+              return const NetworkErrorWidget(
+                errorMessage: Constants.networkError,
+              );
+          }
         },
       ),
     );

--- a/lib/presentation/views/reservation/widget/adapter/remain_seat_list_adapter.dart
+++ b/lib/presentation/views/reservation/widget/adapter/remain_seat_list_adapter.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:reservation_app/domain/model/reservation/reservation_target_part_time_seat_model.dart';
+import 'package:reservation_app/presentation/utils/color_constants.dart';
+
+class RemainSeatListAdapter extends StatefulWidget {
+  final List<ReservationTargetPartTimeSeatModel> seatList;
+  final void Function({
+    required int selectedItem,
+  }) onSelectedSeat;
+
+  const RemainSeatListAdapter({
+    Key? key,
+    required this.seatList,
+    required this.onSelectedSeat,
+  }) : super(key: key);
+
+  @override
+  State<RemainSeatListAdapter> createState() => _RemainSeatListAdapterState();
+}
+
+class _RemainSeatListAdapterState extends State<RemainSeatListAdapter> {
+  List<ReservationTargetPartTimeSeatModel> _updatedSeatList = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _updatedSeatList = List.from(widget.seatList);
+  }
+
+  @override
+  void didUpdateWidget(RemainSeatListAdapter oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (_updatedSeatList != oldWidget.seatList) {
+      setState(() {
+        _updatedSeatList = List.from(widget.seatList);
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        maxHeight: 50,
+        maxWidth: MediaQuery.of(context).size.height,
+      ),
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        itemCount: _updatedSeatList.length,
+        padding: EdgeInsets.all(10),
+        itemBuilder: (BuildContext context, int index) {
+          return GestureDetector(
+            onTap: () {
+              widget.onSelectedSeat(selectedItem: index);
+            },
+            child: Container(
+              width: 50,
+              height: 50,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: _updatedSeatList[index].isSelected
+                    ? ColorsConstants.strokeColor
+                    : ColorsConstants.primaryButtonBackgroundDisabled, // 동그라미의 배경색 지정
+              ),
+              child: Center(
+                child: Text(
+                  _updatedSeatList[index].remainSeatList.name,
+                  style: TextStyle(
+                    color: ColorsConstants.background,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/presentation/views/reservation/widget/close_floating_action_widget.dart
+++ b/lib/presentation/views/reservation/widget/close_floating_action_widget.dart
@@ -4,6 +4,7 @@ import 'package:reservation_app/presentation/utils/color_constants.dart';
 import 'package:reservation_app/presentation/utils/constants.dart';
 import 'package:reservation_app/presentation/utils/dialog_utils.dart';
 import 'package:reservation_app/presentation/views/reservation/bloc/reservation_bloc.dart';
+import 'package:reservation_app/presentation/views/reservation/bloc/second/reservation_second_bloc.dart';
 
 class CloseFloatingActionWidget extends StatefulWidget {
   const CloseFloatingActionWidget({Key? key}) : super(key: key);
@@ -64,6 +65,9 @@ class _CloseFloatingActionWidgetState extends State<CloseFloatingActionWidget>
 
   @override
   Widget build(BuildContext context) {
+    final reservationBloc = context.read<ReservationBloc>();
+    final reservationSecondBloc = context.read<ReservationSecondBloc>();
+
     return BlocConsumer<ReservationBloc, ReservationState>(
       // 이전값과 현재값을 비교하여 true 일 경우에만 listener 실행됨
       listenWhen: (previous, current) {
@@ -135,6 +139,31 @@ class _CloseFloatingActionWidgetState extends State<CloseFloatingActionWidget>
 
               case 1:
                 {
+                  final secondState = reservationSecondBloc.state;
+                  if (secondState is ReservationSecondStateSeatList) {
+                    final seatLists = secondState.seatLists;
+
+                    if (_animateIcon.value == 0 && seatLists.isEmpty) {
+                      DialogUtils.showBasicDialog(
+                        context: context,
+                        title: "알림",
+                        message: "좌석이 꽉 찼어요 ㅠ.ㅠ \n 예약정보 입력 화면으로 넘어갈게요!",
+                        enableCancelBtn: true,
+                        onConfirmClick: () {
+                          reservationBloc.add(
+                            ReservationProcessEvent(
+                              processIndex: (state.currentPosition - 1) %
+                                  Constants
+                                      .reservationProcessList.length,
+                            ),
+                          );
+                        },
+                      );
+
+                      return;
+                    }
+                  }
+
                   if (_animateIcon.value == 0 && state.selectedSeats.isEmpty) {
                     DialogUtils.showBasicDialog(
                       context: context,
@@ -164,7 +193,7 @@ class _CloseFloatingActionWidgetState extends State<CloseFloatingActionWidget>
                 }
             }
 
-            context.read<ReservationBloc>().add(
+            reservationBloc.add(
                   ReservationProcessEvent(
                     processIndex: (state.currentPosition + 1) %
                         Constants.reservationProcessList.length,

--- a/lib/presentation/views/reservation/widget/close_floating_action_widget.dart
+++ b/lib/presentation/views/reservation/widget/close_floating_action_widget.dart
@@ -83,6 +83,10 @@ class _CloseFloatingActionWidgetState extends State<CloseFloatingActionWidget>
 
           case 1:
             {
+              if (_animateIcon.value == 0 && state.selectedSeats.isNotEmpty) {
+                animate();
+              }
+
               break;
             }
 
@@ -128,7 +132,17 @@ class _CloseFloatingActionWidgetState extends State<CloseFloatingActionWidget>
 
               case 1:
                 {
-                  return;
+                  if (_animateIcon.value == 0 && state.selectedSeats.isEmpty) {
+                    DialogUtils.showBasicDialog(
+                      context: context,
+                      title: "알림",
+                      message: "예약 정보에 문제가 없다면\n'해당 날짜로 예약' 버튼을 눌러주세요!",
+                    );
+
+                    return;
+                  }
+
+                  break;
                 }
 
               case 2:
@@ -153,7 +167,6 @@ class _CloseFloatingActionWidgetState extends State<CloseFloatingActionWidget>
                         Constants.reservationProcessList.length,
                   ),
                 );
-
             animate();
           },
           child: AnimatedIcon(

--- a/lib/presentation/views/reservation/widget/close_floating_action_widget.dart
+++ b/lib/presentation/views/reservation/widget/close_floating_action_widget.dart
@@ -67,19 +67,15 @@ class _CloseFloatingActionWidgetState extends State<CloseFloatingActionWidget>
     return BlocConsumer<ReservationBloc, ReservationState>(
       // 이전값과 현재값을 비교하여 true 일 경우에만 listener 실행됨
       listenWhen: (previous, current) {
-        if (previous is ReservationProcessState &&
-            current is ReservationProcessState) {
           // 첫 번째 Process 이고 선택된 예약날짜가 null 이 아니면 listener 시작
-          return _animateIcon.value == 0 && current.currentPosition == 0 && (current.dateTime != null || previous.dateTime != null);
-        }
-
-        return current.currentPosition > previous.currentPosition;
+          return _animateIcon.value == 0 &&
+              current.currentPosition == 0 &&
+              (current.dateTime != null || previous.dateTime != null);
       },
       listener: (context, state) {
         // X 버튼을 다음 버튼으로 바꿔줌
         animate();
-      },
-      // 이전값과 연재값을 비교하여 true 일 경우에만 builder 실행됨
+      }, // 이전값과 연재값을 비교하여 true 일 경우에만 builder 실행됨
       buildWhen: (previous, current) {
         // FloatingActionButton 은 항상 보여야 하므로 true
         return true;
@@ -88,22 +84,22 @@ class _CloseFloatingActionWidgetState extends State<CloseFloatingActionWidget>
         return FloatingActionButton(
           backgroundColor: _animateColor.value,
           onPressed: () {
-            if (_animateIcon.value == 0) {
-              DialogUtils.showBasicDialog(
-                context: context,
-                title: "알림",
-                message: "예약날짜를 선택해 주세요.",
-              );
-
-              return;
-            }
-
-            context.read<ReservationBloc>().add(
-                  ReservationProcessEvent(
-                    processIndex: (state.currentPosition + 1) %
-                        Constants.reservationProcessList.length,
-                  ),
+              if (_animateIcon.value == 0) {
+                DialogUtils.showBasicDialog(
+                  context: context,
+                  title: "알림",
+                  message: "예약날짜를 선택해 주세요.",
                 );
+
+                return;
+              }
+
+              context.read<ReservationBloc>().add(
+                    ReservationProcessEvent(
+                      processIndex: (state.currentPosition + 1) %
+                          Constants.reservationProcessList.length,
+                    ),
+                  );
           },
           child: AnimatedIcon(
             icon: _animateIcon.value == 0

--- a/lib/presentation/views/reservation/widget/close_floating_action_widget.dart
+++ b/lib/presentation/views/reservation/widget/close_floating_action_widget.dart
@@ -85,6 +85,8 @@ class _CloseFloatingActionWidgetState extends State<CloseFloatingActionWidget>
             {
               if (_animateIcon.value == 0 && state.selectedSeats.isNotEmpty) {
                 animate();
+              } else if (_animateIcon.value != 0 && state.selectedSeats.isEmpty) {
+                animate();
               }
 
               break;

--- a/lib/presentation/views/reservation/widget/close_floating_action_widget.dart
+++ b/lib/presentation/views/reservation/widget/close_floating_action_widget.dart
@@ -85,8 +85,9 @@ class _CloseFloatingActionWidgetState extends State<CloseFloatingActionWidget>
             {
               if (_animateIcon.value == 0 && state.selectedSeats.isNotEmpty) {
                 animate();
-              } else if (_animateIcon.value != 0 && state.selectedSeats.isEmpty) {
-                animate();
+              } else if (isOpened && state.selectedSeats.isEmpty) {
+                _animationController.reverse();
+                isOpened = !isOpened;
               }
 
               break;

--- a/lib/presentation/views/reservation/widget/close_floating_action_widget.dart
+++ b/lib/presentation/views/reservation/widget/close_floating_action_widget.dart
@@ -67,14 +67,40 @@ class _CloseFloatingActionWidgetState extends State<CloseFloatingActionWidget>
     return BlocConsumer<ReservationBloc, ReservationState>(
       // 이전값과 현재값을 비교하여 true 일 경우에만 listener 실행됨
       listenWhen: (previous, current) {
-          // 첫 번째 Process 이고 선택된 예약날짜가 null 이 아니면 listener 시작
-          return _animateIcon.value == 0 &&
-              current.currentPosition == 0 &&
-              (current.dateTime != null || previous.dateTime != null);
+        return true;
       },
       listener: (context, state) {
-        // X 버튼을 다음 버튼으로 바꿔줌
-        animate();
+        // ❌ 버튼을 ▶️ 버튼으로 바꿔줌
+        switch (state.currentPosition) {
+          case 0:
+            {
+              if (_animateIcon.value == 0 && state.dateTime != null) {
+                animate();
+              }
+
+              break;
+            }
+
+          case 1:
+            {
+              break;
+            }
+
+          case 2:
+            {
+              break;
+            }
+
+          case 3:
+            {
+              break;
+            }
+
+          case 4:
+            {
+              break;
+            }
+        }
       }, // 이전값과 연재값을 비교하여 true 일 경우에만 builder 실행됨
       buildWhen: (previous, current) {
         // FloatingActionButton 은 항상 보여야 하므로 true
@@ -84,22 +110,51 @@ class _CloseFloatingActionWidgetState extends State<CloseFloatingActionWidget>
         return FloatingActionButton(
           backgroundColor: _animateColor.value,
           onPressed: () {
-              if (_animateIcon.value == 0) {
-                DialogUtils.showBasicDialog(
-                  context: context,
-                  title: "알림",
-                  message: "예약날짜를 선택해 주세요.",
+            switch (state.currentPosition) {
+              case 0:
+                {
+                  if (_animateIcon.value == 0 && state.dateTime == null) {
+                    DialogUtils.showBasicDialog(
+                      context: context,
+                      title: "알림",
+                      message: "예약날짜를 선택해 주세요.",
+                    );
+
+                    return;
+                  }
+
+                  break;
+                }
+
+              case 1:
+                {
+                  return;
+                }
+
+              case 2:
+                {
+                  return;
+                }
+
+              case 3:
+                {
+                  return;
+                }
+
+              case 4:
+                {
+                  return;
+                }
+            }
+
+            context.read<ReservationBloc>().add(
+                  ReservationProcessEvent(
+                    processIndex: (state.currentPosition + 1) %
+                        Constants.reservationProcessList.length,
+                  ),
                 );
 
-                return;
-              }
-
-              context.read<ReservationBloc>().add(
-                    ReservationProcessEvent(
-                      processIndex: (state.currentPosition + 1) %
-                          Constants.reservationProcessList.length,
-                    ),
-                  );
+            animate();
           },
           child: AnimatedIcon(
             icon: _animateIcon.value == 0

--- a/lib/presentation/views/reservation/widget/real_user_input_widget.dart
+++ b/lib/presentation/views/reservation/widget/real_user_input_widget.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:reservation_app/presentation/utils/color_constants.dart';
+
+class RealUserInputWidget extends StatelessWidget {
+  final bool isVisible;
+  final int realSelectedUser;
+
+  final Function() onClickPlus;
+  final Function() onClickMinus;
+
+  const RealUserInputWidget({
+    Key? key,
+    required this.isVisible,
+    required this.realSelectedUser,
+    required this.onClickPlus,
+    required this.onClickMinus,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Visibility(
+      visible: isVisible,
+      child: Container(
+        padding: EdgeInsets.only(left: 25),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.label_important_outline,
+                  size: 20,
+                  color: ColorsConstants.inProgressColor,
+                ),
+                SizedBox(width: 5),
+                Text(
+                  "자세한 인원수 입력: ",
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: ColorsConstants.divider,
+                  ),
+                ),
+                SizedBox(width: 5),
+                Container(
+                  padding: EdgeInsets.all(3),
+                  decoration: BoxDecoration(
+                    border: Border(
+                      bottom: BorderSide(
+                        color: ColorsConstants
+                            .calendarPickerColor, // 테두리 색상 설정
+                        width: 1.0, // 테두리 너비 설정
+                      ),
+                    ),
+                  ),
+                  child: Text(
+                    "$realSelectedUser",
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: ColorsConstants.divider,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            Row(
+              children: [
+                IconButton(
+                  onPressed: onClickPlus,
+                  icon: Icon(
+                    Icons.plus_one_outlined,
+                    size: 20,
+                  ),
+                  color: ColorsConstants.inProgressColor,
+                ),
+                Container(
+                  color: ColorsConstants.divider,
+                  width: 1,
+                  height: 10,
+                  // 구분선의 높이 설정
+                  child: VerticalDivider(),
+                ),
+                IconButton(
+                  onPressed: onClickMinus,
+                  icon: Icon(
+                    Icons.exposure_minus_1_outlined,
+                    size: 20,
+                  ),
+                  color: ColorsConstants.primary,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/views/reservation/widget/reservation_select_count_widget.dart
+++ b/lib/presentation/views/reservation/widget/reservation_select_count_widget.dart
@@ -2,10 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reservation_app/presentation/utils/color_constants.dart';
 import 'package:reservation_app/presentation/views/reservation/bloc/reservation_bloc.dart';
+import 'package:reservation_app/presentation/views/reservation/widget/real_user_input_widget.dart';
 
 // 예약 인원수 선택 Widget
 class ReservationSelectCountWidget extends StatefulWidget {
-  const ReservationSelectCountWidget({Key? key}) : super(key: key);
+  final Function() onScrollBottom;
+
+  const ReservationSelectCountWidget({Key? key, required this.onScrollBottom}) : super(key: key);
 
   @override
   State<ReservationSelectCountWidget> createState() =>
@@ -18,22 +21,27 @@ class _ReservationSelectCountWidgetState
   Widget build(BuildContext context) {
     final reservationBloc = context.read<ReservationBloc>();
 
-    return BlocSelector<ReservationBloc, ReservationState, int>(
-      selector: (state) {
-        return state.selectedCount;
-      },
+    return BlocBuilder<ReservationBloc, ReservationState>(
+      bloc: reservationBloc,
       builder: (context, state) {
         return SizedBox(
-          width: double.infinity,
+          width: MediaQuery.of(context).size.width,
           child: Column(
             children: [
               RadioListTile(
                 value: 0,
-                groupValue: state,
+                groupValue: state.selectedCount,
                 title: Text(
                   "1~3인 이하",
                   style: TextStyle(
                     fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                subtitle: Text(
+                  "좌석을 선택할 수 있어요!",
+                  style: TextStyle(
+                    fontSize: 12,
                     fontWeight: FontWeight.w600,
                   ),
                 ),
@@ -46,11 +54,25 @@ class _ReservationSelectCountWidgetState
                 },
                 activeColor: ColorsConstants.inProgressColor,
                 contentPadding: EdgeInsets.all(0),
-                selected: state == 0,
+                selected: state.selectedCount == 0,
+              ),
+              RealUserInputWidget(
+                isVisible: state.selectedCount == 0,
+                realSelectedUser: state.realUserCount,
+                onClickPlus: () {
+                  reservationBloc.add(
+                    ReservationInputRealUserCountAddEvent(),
+                  );
+                },
+                onClickMinus: () {
+                  reservationBloc.add(
+                    ReservationInputRealUserCountMinusEvent(),
+                  );
+                },
               ),
               RadioListTile(
                 value: 1,
-                groupValue: state,
+                groupValue: state.selectedCount,
                 title: Text(
                   "4~5인 이하",
                   style: TextStyle(
@@ -74,11 +96,25 @@ class _ReservationSelectCountWidgetState
                 },
                 activeColor: ColorsConstants.inProgressColor,
                 contentPadding: EdgeInsets.all(0),
-                selected: state == 1,
+                selected: state.selectedCount == 1,
+              ),
+              RealUserInputWidget(
+                isVisible: state.selectedCount == 1,
+                realSelectedUser: state.realUserCount,
+                onClickPlus: () {
+                  reservationBloc.add(
+                    ReservationInputRealUserCountAddEvent(),
+                  );
+                },
+                onClickMinus: () {
+                  reservationBloc.add(
+                    ReservationInputRealUserCountMinusEvent(),
+                  );
+                },
               ),
               RadioListTile(
                 value: 2,
-                groupValue: state,
+                groupValue: state.selectedCount,
                 title: Text(
                   "6인 이상",
                   style: TextStyle(
@@ -99,10 +135,31 @@ class _ReservationSelectCountWidgetState
                       reservationCount: val ?? 2,
                     ),
                   );
+                  widget.onScrollBottom();
                 },
                 activeColor: ColorsConstants.inProgressColor,
                 contentPadding: EdgeInsets.all(0),
-                selected: state == 2,
+                selected: state.selectedCount == 2,
+              ),
+              RealUserInputWidget(
+                isVisible: state.selectedCount == 2,
+                realSelectedUser: state.realUserCount,
+                onClickPlus: () {
+                  reservationBloc.add(
+                    ReservationInputRealUserCountAddEvent(),
+                  );
+                },
+                onClickMinus: () {
+                  reservationBloc.add(
+                    ReservationInputRealUserCountMinusEvent(),
+                  );
+                },
+              ),
+              Visibility(
+                visible: state.selectedCount == 2,
+                child: Container(
+                  constraints: const BoxConstraints.expand(height: 50.0),
+                ),
               ),
             ],
           ),

--- a/lib/presentation/views/reservation/widget/reservation_select_count_widget.dart
+++ b/lib/presentation/views/reservation/widget/reservation_select_count_widget.dart
@@ -20,11 +20,7 @@ class _ReservationSelectCountWidgetState
 
     return BlocSelector<ReservationBloc, ReservationState, int>(
       selector: (state) {
-        if (state is ReservationProcessState) {
-          return state.selectedCount;
-        } else {
-          return 0;
-        }
+        return state.selectedCount;
       },
       builder: (context, state) {
         return SizedBox(

--- a/lib/presentation/views/reservation/widget/reservation_select_date_widget.dart
+++ b/lib/presentation/views/reservation/widget/reservation_select_date_widget.dart
@@ -42,11 +42,7 @@ class _ReservationSelectDateWidgetState
         ),
         BlocSelector<ReservationBloc, ReservationState, DateTime?>(
           selector: (state) {
-            if (state is ReservationProcessState) {
-              return state.dateTime;
-            } else {
-              return null;
-            }
+            return state.dateTime;
           },
           builder: (context, state) {
             return OutlinedButton(
@@ -74,7 +70,6 @@ class _ReservationSelectDateWidgetState
                   },
                 ).then((value) {
                   // 확인 버튼 눌렀을 경우 Callback
-                  debugPrint("🌹 value 👉 $value");
                   if (value != null) {
                     reservationBloc.add(
                       ReservationDatePickerEvent(

--- a/lib/presentation/views/reservation/widget/reservation_select_time_widget.dart
+++ b/lib/presentation/views/reservation/widget/reservation_select_time_widget.dart
@@ -83,7 +83,7 @@ class _ReservationSelectTimeWidgetState
                 value: 2,
                 groupValue: state,
                 title: Text(
-                  "PM 5:50",
+                  "PM 8:00",
                   style: TextStyle(
                     fontSize: 12,
                     fontWeight: FontWeight.w600,

--- a/lib/presentation/views/reservation/widget/reservation_select_time_widget.dart
+++ b/lib/presentation/views/reservation/widget/reservation_select_time_widget.dart
@@ -20,11 +20,7 @@ class _ReservationSelectTimeWidgetState
 
     return BlocSelector<ReservationBloc, ReservationState, int>(
       selector: (state) {
-        if (state is ReservationProcessState) {
-          return state.selectedTime;
-        } else {
-          return 0;
-        }
+        return state.selectedTime;
       },
       builder: (context, state) {
         return SizedBox(


### PR DESCRIPTION
## 🌸 예약기능
- 이 브런치는 두 번째 Process 인 **_좌석 선택_** 작업에 관한 브런치임
  > **_📌 참고_**
  > -
  > #### 📍 예약 Process
  > - 1️⃣ 예약정보 입력
  > - 2️⃣ **_좌석 선택_**
  > - 3️⃣ 약관동의
  > - 4️⃣ 본인인증
  > - 5️⃣ 예약완료

- `/reservation/seats` API 추가 👉 특정 날짜의 원하는 PartTime에 남아있는 좌석 List 를 조회하는 API

- Bloc 구조 변경 👉 기존에 Bloc 을 잘못이해하고, 하나의 Bloc 에서 모든 `State` 를 조작하려 했으나 불가능함을 깨닫고 상태별로 Bloc 을 만들어 관리할 수 있도록 수정
  > - 참고 👉 [Bloc 관련 블로그](https://engineering.linecorp.com/ko/blog/flutter-architecture-getx-bloc-provider)

- 1인 석의 경우 좌석을 선택할 수 있도록 구현
  > - 1인 석의 경우 **_좌석 선택_** 가능
  > - 나머지 `4~5`, `6~8` 인석의 경우 어짜피 테이블이 정해져 있으므로, **_좌석 선택_** 을 할 필요가 없음

- 좌석이 없는 경우 대응
  > - 좌석이 매진된 경우 **_예약 정보 변경_** 버튼만 보여지며 클릭 시 이전 단계인 예약 Process 1부분으로 다시 돌아가도록 구현
  > - 하단의 FloatingActionButton 클릭 시 `AlertDialog` 를 보여주고, `AlertDialog` 의 **_확인_** 버튼 클릭 시 Process 1 버전으로 넘어가도록 구현