### PR TITLE
🦋 예약 기능 4️⃣ - 본인 인증 🦋

### DIFF
--- a/lib/data/common/response/response_base.dart
+++ b/lib/data/common/response/response_base.dart
@@ -4,17 +4,18 @@ import 'package:json_annotation/json_annotation.dart';
 part 'response_base.g.dart';
 
 @JsonSerializable(genericArgumentFactories: true)
-class BaseResponse<T extends Equatable> {
+class BaseResponse<T> {
   bool success;
   String? resultMsg;
   int code;
   T? data;
 
-  BaseResponse(
-      {required this.success,
-      required this.resultMsg,
-      required this.data,
-      required this.code});
+  BaseResponse({
+    required this.success,
+    required this.resultMsg,
+    required this.data,
+    required this.code,
+  });
 
   factory BaseResponse.fromJson(
           Map<String, dynamic> json, T Function(Object?) fromJsonT) =>

--- a/lib/data/common/response/response_base.g.dart
+++ b/lib/data/common/response/response_base.g.dart
@@ -6,7 +6,7 @@ part of 'response_base.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-BaseResponse<T> _$BaseResponseFromJson<T extends Equatable>(
+BaseResponse<T> _$BaseResponseFromJson<T>(
   Map<String, dynamic> json,
   T Function(Object? json) fromJsonT,
 ) =>
@@ -17,7 +17,7 @@ BaseResponse<T> _$BaseResponseFromJson<T extends Equatable>(
       code: json['code'] as int,
     );
 
-Map<String, dynamic> _$BaseResponseToJson<T extends Equatable>(
+Map<String, dynamic> _$BaseResponseToJson<T>(
   BaseResponse<T> instance,
   Object? Function(T value) toJsonT,
 ) =>

--- a/lib/data/datasources/remote/sign/sign_api_service.dart
+++ b/lib/data/datasources/remote/sign/sign_api_service.dart
@@ -1,0 +1,17 @@
+
+import 'package:dio/dio.dart';
+import 'package:reservation_app/data/common/response/response_base.dart';
+import 'package:reservation_app/data/model/sign/phone_auth_request.dart';
+import 'package:retrofit/http.dart';
+
+part 'sign_api_service.g.dart';
+
+@RestApi()
+abstract class SignApiService {
+  factory SignApiService(Dio dio, {String? baseUrl}) = _SignApiService;
+
+  @POST("/sign/phone")
+  Future<BaseResponse> requestAuthPhoneNumber(
+    @Body() PhoneAuthRequest request
+  );
+}

--- a/lib/data/datasources/remote/sign/sign_api_service.dart
+++ b/lib/data/datasources/remote/sign/sign_api_service.dart
@@ -1,6 +1,6 @@
-
 import 'package:dio/dio.dart';
 import 'package:reservation_app/data/common/response/response_base.dart';
+import 'package:reservation_app/data/model/sign/phone_auth_check_request.dart';
 import 'package:reservation_app/data/model/sign/phone_auth_request.dart';
 import 'package:retrofit/http.dart';
 
@@ -12,6 +12,11 @@ abstract class SignApiService {
 
   @POST("/sign/phone")
   Future<BaseResponse> requestAuthPhoneNumber(
-    @Body() PhoneAuthRequest request
+    @Body() PhoneAuthRequest request,
+  );
+
+  @POST("/sign/phone/check")
+  Future<BaseResponse> requestAuthPhoneNumberCheck(
+    @Body() PhoneAuthCheckRequest request,
   );
 }

--- a/lib/data/datasources/remote/sign/sign_api_service.g.dart
+++ b/lib/data/datasources/remote/sign/sign_api_service.g.dart
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'sign_api_service.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers
+
+class _SignApiService implements SignApiService {
+  _SignApiService(
+    this._dio, {
+    this.baseUrl,
+  });
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  @override
+  Future<BaseResponse<dynamic>> requestAuthPhoneNumber(request) async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(request.toJson());
+    final _result = await _dio.fetch<Map<String, dynamic>>(
+        _setStreamType<BaseResponse<dynamic>>(Options(
+      method: 'POST',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/sign/phone',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    final value = BaseResponse<dynamic>.fromJson(
+      _result.data!,
+      (json) => json as dynamic,
+    );
+    return value;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+}

--- a/lib/data/datasources/remote/sign/sign_api_service.g.dart
+++ b/lib/data/datasources/remote/sign/sign_api_service.g.dart
@@ -45,6 +45,33 @@ class _SignApiService implements SignApiService {
     return value;
   }
 
+  @override
+  Future<BaseResponse<dynamic>> requestAuthPhoneNumberCheck(request) async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(request.toJson());
+    final _result = await _dio.fetch<Map<String, dynamic>>(
+        _setStreamType<BaseResponse<dynamic>>(Options(
+      method: 'POST',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/sign/phone/check',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    final value = BaseResponse<dynamic>.fromJson(
+      _result.data!,
+      (json) => json as dynamic,
+    );
+    return value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/data/model/sign/phone_auth_check_request.dart
+++ b/lib/data/model/sign/phone_auth_check_request.dart
@@ -1,0 +1,30 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'phone_auth_check_request.g.dart';
+
+@JsonSerializable()
+class PhoneAuthCheckRequest extends Equatable {
+  final String name;
+  final String phoneNumber;
+  final String authenticationCode;
+
+  const PhoneAuthCheckRequest({
+    required this.name,
+    required this.phoneNumber,
+    required this.authenticationCode,
+  });
+
+  factory PhoneAuthCheckRequest.fromJson(Map<String, dynamic> json) => _$PhoneAuthCheckRequestFromJson(json);
+  Map<String, dynamic> toJson() => _$PhoneAuthCheckRequestToJson(this);
+
+  @override
+  List<Object?> get props => [
+    name,
+    phoneNumber,
+    authenticationCode,
+  ];
+
+  @override
+  bool? get stringify => false;
+}

--- a/lib/data/model/sign/phone_auth_check_request.g.dart
+++ b/lib/data/model/sign/phone_auth_check_request.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'phone_auth_check_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+PhoneAuthCheckRequest _$PhoneAuthCheckRequestFromJson(
+        Map<String, dynamic> json) =>
+    PhoneAuthCheckRequest(
+      name: json['name'] as String,
+      phoneNumber: json['phoneNumber'] as String,
+      authenticationCode: json['authenticationCode'] as String,
+    );
+
+Map<String, dynamic> _$PhoneAuthCheckRequestToJson(
+        PhoneAuthCheckRequest instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'phoneNumber': instance.phoneNumber,
+      'authenticationCode': instance.authenticationCode,
+    };

--- a/lib/data/model/sign/phone_auth_request.dart
+++ b/lib/data/model/sign/phone_auth_request.dart
@@ -1,0 +1,39 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'phone_auth_request.g.dart';
+
+@JsonSerializable()
+class PhoneAuthRequest extends Equatable {
+  final String name;
+  final String phoneNumber;
+
+  const PhoneAuthRequest({
+    required this.name,
+    required this.phoneNumber,
+  });
+
+  factory PhoneAuthRequest.fromJson(Map<String, dynamic> json) =>
+      _$PhoneAuthRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PhoneAuthRequestToJson(this);
+
+  PhoneAuthRequest copyWith({
+    String? name,
+    String? phoneNumber,
+  }) {
+    return PhoneAuthRequest(
+      name: name ?? this.name,
+      phoneNumber: phoneNumber ?? this.phoneNumber,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        name,
+        phoneNumber,
+      ];
+
+  @override
+  bool? get stringify => false;
+}

--- a/lib/data/model/sign/phone_auth_request.g.dart
+++ b/lib/data/model/sign/phone_auth_request.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'phone_auth_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+PhoneAuthRequest _$PhoneAuthRequestFromJson(Map<String, dynamic> json) =>
+    PhoneAuthRequest(
+      name: json['name'] as String,
+      phoneNumber: json['phoneNumber'] as String,
+    );
+
+Map<String, dynamic> _$PhoneAuthRequestToJson(PhoneAuthRequest instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'phoneNumber': instance.phoneNumber,
+    };

--- a/lib/data/repository/sign/sign_repository_impl.dart
+++ b/lib/data/repository/sign/sign_repository_impl.dart
@@ -1,7 +1,7 @@
-
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:reservation_app/data/datasources/remote/sign/sign_api_service.dart';
+import 'package:reservation_app/data/model/sign/phone_auth_check_request.dart';
 import 'package:reservation_app/data/model/sign/phone_auth_request.dart';
 import 'package:reservation_app/domain/model/base/data_state.dart';
 import 'package:reservation_app/domain/repository/sign/sign_repository.dart';
@@ -12,7 +12,9 @@ class SignRepositoryImpl implements SignRepository {
   SignRepositoryImpl(this._signApiService);
 
   @override
-  Future<DataState<bool>> getAuthenticationNumber(PhoneAuthRequest request) async {
+  Future<DataState<bool>> getAuthenticationNumber(
+    PhoneAuthRequest request,
+  ) async {
     try {
       final response = await _signApiService.requestAuthPhoneNumber(request);
 
@@ -27,6 +29,28 @@ class SignRepositoryImpl implements SignRepository {
       return DataNetworkError(response.resultMsg);
     } on DioException catch (error) {
       debugPrint("🌹 [/sign/phone] API DioException 👉 ${error.message}");
+      return DataError(error);
+    }
+  }
+
+  @override
+  Future<DataState<bool>> getAuthenticationNumberCheck(
+    PhoneAuthCheckRequest request,
+  ) async {
+    try {
+      final response = await _signApiService.requestAuthPhoneNumberCheck(request);
+
+      if (response.success && response.code == 200) {
+        if (response.resultMsg != null && response.resultMsg == "응답 성공") {
+          return DataSuccess(true);
+        }
+
+        return DataSuccess(false);
+      }
+
+      return DataNetworkError(response.resultMsg);
+    } on DioException catch (error) {
+      debugPrint("🌹 [/sign/phone/check] API DioException 👉 ${error.message}");
       return DataError(error);
     }
   }

--- a/lib/data/repository/sign/sign_repository_impl.dart
+++ b/lib/data/repository/sign/sign_repository_impl.dart
@@ -1,0 +1,33 @@
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:reservation_app/data/datasources/remote/sign/sign_api_service.dart';
+import 'package:reservation_app/data/model/sign/phone_auth_request.dart';
+import 'package:reservation_app/domain/model/base/data_state.dart';
+import 'package:reservation_app/domain/repository/sign/sign_repository.dart';
+
+class SignRepositoryImpl implements SignRepository {
+  final SignApiService _signApiService;
+
+  SignRepositoryImpl(this._signApiService);
+
+  @override
+  Future<DataState<bool>> getAuthenticationNumber(PhoneAuthRequest request) async {
+    try {
+      final response = await _signApiService.requestAuthPhoneNumber(request);
+
+      if (response.success && response.code == 200) {
+        if (response.resultMsg != null && response.resultMsg == "응답 성공") {
+          return DataSuccess(true);
+        }
+
+        return DataSuccess(false);
+      }
+
+      return DataNetworkError(response.resultMsg);
+    } on DioException catch (error) {
+      debugPrint("🌹 [/sign/phone] API DioException 👉 ${error.message}");
+      return DataError(error);
+    }
+  }
+}

--- a/lib/di/dependency_inection_graph.dart
+++ b/lib/di/dependency_inection_graph.dart
@@ -18,6 +18,7 @@ import 'package:reservation_app/domain/usecase/banner/get_all_banner_image_use_c
 import 'package:reservation_app/domain/usecase/notice/get_all_notice_list_use_case.dart';
 import 'package:reservation_app/domain/usecase/reservation/get_reservation_target_part_time_use_case.dart';
 import 'package:reservation_app/domain/usecase/reservation/get_tartget_date_reservation_use_case.dart';
+import 'package:reservation_app/domain/usecase/sign/get_auth_phone_number_check_use_case.dart';
 import 'package:reservation_app/domain/usecase/sign/get_auth_phone_number_use_case.dart';
 import 'package:reservation_app/presentation/views/main/block/main_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/home/block/home_tab_bloc.dart';
@@ -98,6 +99,11 @@ Future<void> initializeDependencies() async {
   locator.registerLazySingleton<GetAuthPhoneNumberUseCase>(
     () => GetAuthPhoneNumberUseCase(locator<SignRepository>()),
   );
+  locator.registerLazySingleton<GetAuthPhoneNumberCheckUseCase>(
+    () => GetAuthPhoneNumberCheckUseCase(
+      locator<SignRepository>(),
+    ),
+  );
 
   // 📌 Block
   locator.registerFactory(() => MainBloc());
@@ -123,6 +129,9 @@ Future<void> initializeDependencies() async {
     () => ContentNoticeTabBloc(locator<GetAllNoticeListUseCase>()),
   );
   locator.registerFactory(
-    () => ReservationFourthBloc(locator<GetAuthPhoneNumberUseCase>()),
+    () => ReservationFourthBloc(
+      locator<GetAuthPhoneNumberUseCase>(),
+      locator<GetAuthPhoneNumberCheckUseCase>(),
+    ),
   );
 }

--- a/lib/di/dependency_inection_graph.dart
+++ b/lib/di/dependency_inection_graph.dart
@@ -3,23 +3,28 @@ import 'package:get_it/get_it.dart';
 import 'package:reservation_app/data/datasources/remote/banner/banner_api_service.dart';
 import 'package:reservation_app/data/datasources/remote/notice/notice_api_service.dart';
 import 'package:reservation_app/data/datasources/remote/reservation/reservation_api_service.dart';
+import 'package:reservation_app/data/datasources/remote/sign/sign_api_service.dart';
 import 'package:reservation_app/data/repository/banner/banner_repository_impl.dart';
 import 'package:reservation_app/data/repository/notice/notice_repository_impl.dart';
 import 'package:reservation_app/data/repository/reservation/reservation_repository_impl.dart';
+import 'package:reservation_app/data/repository/sign/sign_repository_impl.dart';
 import 'package:reservation_app/di/network/network_module.dart';
 import 'package:reservation_app/di/prefs/shared_pref_module.dart';
 import 'package:reservation_app/domain/repository/banner/banner_repository.dart';
 import 'package:reservation_app/domain/repository/notice/notice_repository.dart';
 import 'package:reservation_app/domain/repository/reservation/reservation_repository.dart';
+import 'package:reservation_app/domain/repository/sign/sign_repository.dart';
 import 'package:reservation_app/domain/usecase/banner/get_all_banner_image_use_case.dart';
 import 'package:reservation_app/domain/usecase/notice/get_all_notice_list_use_case.dart';
 import 'package:reservation_app/domain/usecase/reservation/get_reservation_target_part_time_use_case.dart';
 import 'package:reservation_app/domain/usecase/reservation/get_tartget_date_reservation_use_case.dart';
+import 'package:reservation_app/domain/usecase/sign/get_auth_phone_number_use_case.dart';
 import 'package:reservation_app/presentation/views/main/block/main_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/home/block/home_tab_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/home/tabs/home/bloc/content_home_tab_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/home/tabs/location/bloc/content_location_tab_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/home/tabs/notice/bloc/content_notice_tab_bloc.dart';
+import 'package:reservation_app/presentation/views/reservation/bloc/fourth/reservation_fourth_bloc.dart';
 import 'package:reservation_app/presentation/views/reservation/bloc/reservation_bloc.dart';
 import 'package:reservation_app/presentation/views/reservation/bloc/second/reservation_second_bloc.dart';
 import 'package:reservation_app/presentation/views/reservation/bloc/third/reservation_third_bloc.dart';
@@ -59,6 +64,9 @@ Future<void> initializeDependencies() async {
   locator.registerLazySingleton<NoticeApiService>(
     () => NoticeApiService(locator<Dio>()),
   );
+  locator.registerLazySingleton<SignApiService>(
+    () => SignApiService(locator<Dio>()),
+  );
 
   // 📌 Repository
   locator.registerLazySingleton<BannerRepository>(
@@ -69,6 +77,9 @@ Future<void> initializeDependencies() async {
   );
   locator.registerLazySingleton<NoticeRepository>(
     () => NoticeRepositoryImpl(locator<NoticeApiService>()),
+  );
+  locator.registerLazySingleton<SignRepository>(
+    () => SignRepositoryImpl(locator<SignApiService>()),
   );
 
   // 📌 UseCase
@@ -83,6 +94,9 @@ Future<void> initializeDependencies() async {
   );
   locator.registerLazySingleton<GetReservationTargetPartTimeUseCase>(
     () => GetReservationTargetPartTimeUseCase(locator<ReservationRepository>()),
+  );
+  locator.registerLazySingleton<GetAuthPhoneNumberUseCase>(
+    () => GetAuthPhoneNumberUseCase(locator<SignRepository>()),
   );
 
   // 📌 Block
@@ -107,5 +121,8 @@ Future<void> initializeDependencies() async {
   );
   locator.registerFactory(
     () => ContentNoticeTabBloc(locator<GetAllNoticeListUseCase>()),
+  );
+  locator.registerFactory(
+    () => ReservationFourthBloc(locator<GetAuthPhoneNumberUseCase>()),
   );
 }

--- a/lib/domain/repository/sign/sign_repository.dart
+++ b/lib/domain/repository/sign/sign_repository.dart
@@ -1,7 +1,10 @@
 
+import 'package:reservation_app/data/model/sign/phone_auth_check_request.dart';
 import 'package:reservation_app/data/model/sign/phone_auth_request.dart';
 import 'package:reservation_app/domain/model/base/data_state.dart';
 
 abstract class SignRepository {
   Future<DataState<bool>> getAuthenticationNumber(PhoneAuthRequest request);
+
+  Future<DataState<bool>> getAuthenticationNumberCheck(PhoneAuthCheckRequest request);
 }

--- a/lib/domain/repository/sign/sign_repository.dart
+++ b/lib/domain/repository/sign/sign_repository.dart
@@ -1,0 +1,7 @@
+
+import 'package:reservation_app/data/model/sign/phone_auth_request.dart';
+import 'package:reservation_app/domain/model/base/data_state.dart';
+
+abstract class SignRepository {
+  Future<DataState<bool>> getAuthenticationNumber(PhoneAuthRequest request);
+}

--- a/lib/domain/usecase/sign/get_auth_phone_number_check_use_case.dart
+++ b/lib/domain/usecase/sign/get_auth_phone_number_check_use_case.dart
@@ -1,0 +1,13 @@
+import 'package:reservation_app/data/model/sign/phone_auth_check_request.dart';
+import 'package:reservation_app/domain/model/base/data_state.dart';
+import 'package:reservation_app/domain/repository/sign/sign_repository.dart';
+
+class GetAuthPhoneNumberCheckUseCase {
+  final SignRepository _signRepository;
+
+  GetAuthPhoneNumberCheckUseCase(this._signRepository);
+
+  Future<DataState<bool>> invoke(PhoneAuthCheckRequest request) {
+    return _signRepository.getAuthenticationNumberCheck(request);
+  }
+}

--- a/lib/domain/usecase/sign/get_auth_phone_number_use_case.dart
+++ b/lib/domain/usecase/sign/get_auth_phone_number_use_case.dart
@@ -1,0 +1,14 @@
+
+import 'package:reservation_app/data/model/sign/phone_auth_request.dart';
+import 'package:reservation_app/domain/model/base/data_state.dart';
+import 'package:reservation_app/domain/repository/sign/sign_repository.dart';
+
+class GetAuthPhoneNumberUseCase {
+  final SignRepository _signRepository;
+
+  GetAuthPhoneNumberUseCase(this._signRepository);
+
+  Future<DataState<bool>> invoke(PhoneAuthRequest request) {
+    return _signRepository.getAuthenticationNumber(request);
+  }
+}

--- a/lib/presentation/utils/color_constants.dart
+++ b/lib/presentation/utils/color_constants.dart
@@ -28,6 +28,8 @@ class ColorsConstants {
   static const Color textDark = Color(0xFFFFFFFF);
   static const Color textLight = Color(0xFFEEEEEE);
   static const Color textExtraLight = Color(0xFFCCCCCC);
+  static const Color textHint = Color(0xFFBEC0C7);
+  static const Color inputFocus = Color(0xFF01BFB1);
 
   // Button Primary
   static const Color primaryButtonBackground = Color(0xFFFFFFFF);

--- a/lib/presentation/utils/date_time_utils.dart
+++ b/lib/presentation/utils/date_time_utils.dart
@@ -26,4 +26,10 @@ class DateTimeUtils {
   static String dateTimeToWeekDay({required DateTime date}) {
     return DateFormat('EEEE', 'ko_KR').format(date);
   }
+
+  static String formatDuration(int durationInSeconds) {
+    int minutes = durationInSeconds ~/ 60;
+    int seconds = durationInSeconds % 60;
+    return '${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
+  }
 }

--- a/lib/presentation/utils/text_utils.dart
+++ b/lib/presentation/utils/text_utils.dart
@@ -1,0 +1,13 @@
+
+class TextUtils {
+  static bool isNameValid(String text) {
+    // 2~4 자리 한글 이름 검사
+    RegExp regex = RegExp(r'^[가-힣]{2,4}$');
+    return regex.hasMatch(text);
+  }
+
+  static bool isPhoneNumberValid(String text) {
+    RegExp regex = RegExp(r'^01([0|1|6|7|8|9])-?([0-9]{3,4})-?([0-9]{4})$');
+    return regex.hasMatch(text);
+  }
+}

--- a/lib/presentation/views/reservation/bloc/fourth/reservation_fourth_bloc.dart
+++ b/lib/presentation/views/reservation/bloc/fourth/reservation_fourth_bloc.dart
@@ -1,9 +1,14 @@
-import 'package:equatable/equatable.dart';
-import 'package:flutter/cupertino.dart';
+import 'dart:async';
+
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:reservation_app/data/model/sign/phone_auth_check_request.dart';
 import 'package:reservation_app/data/model/sign/phone_auth_request.dart';
 import 'package:reservation_app/domain/model/base/data_state.dart';
+import 'package:reservation_app/domain/usecase/sign/get_auth_phone_number_check_use_case.dart';
 import 'package:reservation_app/domain/usecase/sign/get_auth_phone_number_use_case.dart';
+
+part 'reservation_fourth_bloc.freezed.dart';
 
 part 'reservation_fourth_event.dart';
 
@@ -12,35 +17,113 @@ part 'reservation_fourth_state.dart';
 class ReservationFourthBloc
     extends Bloc<ReservationFourthEvent, ReservationFourthState> {
   final GetAuthPhoneNumberUseCase _getAuthPhoneNumberUseCase;
+  final GetAuthPhoneNumberCheckUseCase _getAuthPhoneNumberCheckUseCase;
 
-  ReservationFourthBloc(this._getAuthPhoneNumberUseCase)
-      : super(ReservationFourthState.initial()) {
-    on<ReservationFourthGetPhoneAuthNumberEvent>(
+  ReservationFourthBloc(
+    this._getAuthPhoneNumberUseCase,
+    this._getAuthPhoneNumberCheckUseCase,
+  ) : super(const ReservationFourthState()) {
+    on<ReservationFourthRequestPhoneAuthNumber>(
       (event, emit) => _requestPhoneAuthNumber(event, emit),
+    );
+    on<ReservationFourthRequestPhoneAuthCheck>(
+      (event, emit) => _requestAuthCodeCheck(event, emit),
     );
   }
 
-  void _requestPhoneAuthNumber(
-    ReservationFourthGetPhoneAuthNumberEvent event,
+  FutureOr<void> _requestPhoneAuthNumber(
+    ReservationFourthRequestPhoneAuthNumber event,
     Emitter<ReservationFourthState> emit,
   ) async {
-    emit(state.copyWith(sendMessageStateType: SentMessageStateType.loading));
+    emit(state.copyWith(reqAuthNumberStatus: RequestAuthNumberStatus.loading));
 
     final response = await _getAuthPhoneNumberUseCase.invoke(
       PhoneAuthRequest(
-        name: state.name,
-        phoneNumber: state.phoneNumber,
+        name: event.name,
+        phoneNumber: event.phoneNumber,
       ),
     );
 
     if (response is DataSuccess) {
-      emit(state.copyWith(isSentMessageSuccessfully: response.data ?? false));
+      emit(
+        state.copyWith(
+          reqAuthNumberStatus: RequestAuthNumberStatus.success,
+          isRequestSuccess: response.data ?? false,
+          name: event.name,
+          phoneNumber: event.phoneNumber,
+        ),
+      );
     } else if (response is DataError) {
-      emit(state.copyWith(sendMessageStateType: SentMessageStateType.failure));
+      emit(
+        state.copyWith(
+          reqAuthNumberStatus: RequestAuthNumberStatus.error,
+          isRequestSuccess: false,
+        ),
+      );
     } else if (response is DataNetworkError) {
-      emit(state.copyWith(sendMessageStateType: SentMessageStateType.failure));
+      emit(
+        state.copyWith(
+          reqAuthNumberStatus: RequestAuthNumberStatus.error,
+          isRequestSuccess: false,
+        ),
+      );
     } else {
-      emit(state.copyWith(sendMessageStateType: SentMessageStateType.failure));
+      emit(
+        state.copyWith(
+          reqAuthNumberStatus: RequestAuthNumberStatus.error,
+          isRequestSuccess: false,
+        ),
+      );
+    }
+  }
+
+  FutureOr<void> _requestAuthCodeCheck(
+    ReservationFourthRequestPhoneAuthCheck event,
+    Emitter<ReservationFourthState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        reqAuthNumberStatus: RequestAuthNumberStatus.initial,
+        checkAuthNumberStatus: CheckAuthNumberStatus.loading,
+      ),
+    );
+
+    final response = await _getAuthPhoneNumberCheckUseCase.invoke(
+      PhoneAuthCheckRequest(
+        name: state.name,
+        phoneNumber: state.phoneNumber,
+        authenticationCode: event.authCode,
+      ),
+    );
+
+    if (response is DataSuccess) {
+      emit(
+        state.copyWith(
+          checkAuthNumberStatus: CheckAuthNumberStatus.success,
+          isCheckSuccess: response.data ?? false,
+        ),
+      );
+    } else if (response is DataError) {
+      emit(
+        state.copyWith(
+          checkAuthNumberStatus: CheckAuthNumberStatus.error,
+          isCheckSuccess: false,
+        ),
+      );
+    } else if (response is DataNetworkError) {
+      emit(
+        state.copyWith(
+          checkAuthNumberStatus: CheckAuthNumberStatus.error,
+          isCheckSuccess: false,
+        ),
+      );
+    } else {
+      emit(
+        state.copyWith(
+          checkAuthNumberStatus: CheckAuthNumberStatus.error,
+          isCheckSuccess: false,
+        ),
+      );
     }
   }
 }

--- a/lib/presentation/views/reservation/bloc/fourth/reservation_fourth_bloc.dart
+++ b/lib/presentation/views/reservation/bloc/fourth/reservation_fourth_bloc.dart
@@ -1,0 +1,46 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reservation_app/data/model/sign/phone_auth_request.dart';
+import 'package:reservation_app/domain/model/base/data_state.dart';
+import 'package:reservation_app/domain/usecase/sign/get_auth_phone_number_use_case.dart';
+
+part 'reservation_fourth_event.dart';
+
+part 'reservation_fourth_state.dart';
+
+class ReservationFourthBloc
+    extends Bloc<ReservationFourthEvent, ReservationFourthState> {
+  final GetAuthPhoneNumberUseCase _getAuthPhoneNumberUseCase;
+
+  ReservationFourthBloc(this._getAuthPhoneNumberUseCase)
+      : super(ReservationFourthState.initial()) {
+    on<ReservationFourthGetPhoneAuthNumberEvent>(
+      (event, emit) => _requestPhoneAuthNumber(event, emit),
+    );
+  }
+
+  void _requestPhoneAuthNumber(
+    ReservationFourthGetPhoneAuthNumberEvent event,
+    Emitter<ReservationFourthState> emit,
+  ) async {
+    emit(state.copyWith(sendMessageStateType: SentMessageStateType.loading));
+
+    final response = await _getAuthPhoneNumberUseCase.invoke(
+      PhoneAuthRequest(
+        name: state.name,
+        phoneNumber: state.phoneNumber,
+      ),
+    );
+
+    if (response is DataSuccess) {
+      emit(state.copyWith(isSentMessageSuccessfully: response.data ?? false));
+    } else if (response is DataError) {
+      emit(state.copyWith(sendMessageStateType: SentMessageStateType.failure));
+    } else if (response is DataNetworkError) {
+      emit(state.copyWith(sendMessageStateType: SentMessageStateType.failure));
+    } else {
+      emit(state.copyWith(sendMessageStateType: SentMessageStateType.failure));
+    }
+  }
+}

--- a/lib/presentation/views/reservation/bloc/fourth/reservation_fourth_bloc.freezed.dart
+++ b/lib/presentation/views/reservation/bloc/fourth/reservation_fourth_bloc.freezed.dart
@@ -1,0 +1,635 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'reservation_fourth_bloc.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$ReservationFourthEvent {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String name, String phoneNumber)
+        requestPhoneAuthNumber,
+    required TResult Function(String authCode) requestPhoneAuthNumberCheck,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String name, String phoneNumber)? requestPhoneAuthNumber,
+    TResult? Function(String authCode)? requestPhoneAuthNumberCheck,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String name, String phoneNumber)? requestPhoneAuthNumber,
+    TResult Function(String authCode)? requestPhoneAuthNumberCheck,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ReservationFourthRequestPhoneAuthNumber value)
+        requestPhoneAuthNumber,
+    required TResult Function(ReservationFourthRequestPhoneAuthCheck value)
+        requestPhoneAuthNumberCheck,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ReservationFourthRequestPhoneAuthNumber value)?
+        requestPhoneAuthNumber,
+    TResult? Function(ReservationFourthRequestPhoneAuthCheck value)?
+        requestPhoneAuthNumberCheck,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ReservationFourthRequestPhoneAuthNumber value)?
+        requestPhoneAuthNumber,
+    TResult Function(ReservationFourthRequestPhoneAuthCheck value)?
+        requestPhoneAuthNumberCheck,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReservationFourthEventCopyWith<$Res> {
+  factory $ReservationFourthEventCopyWith(ReservationFourthEvent value,
+          $Res Function(ReservationFourthEvent) then) =
+      _$ReservationFourthEventCopyWithImpl<$Res, ReservationFourthEvent>;
+}
+
+/// @nodoc
+class _$ReservationFourthEventCopyWithImpl<$Res,
+        $Val extends ReservationFourthEvent>
+    implements $ReservationFourthEventCopyWith<$Res> {
+  _$ReservationFourthEventCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$ReservationFourthRequestPhoneAuthNumberCopyWith<$Res> {
+  factory _$$ReservationFourthRequestPhoneAuthNumberCopyWith(
+          _$ReservationFourthRequestPhoneAuthNumber value,
+          $Res Function(_$ReservationFourthRequestPhoneAuthNumber) then) =
+      __$$ReservationFourthRequestPhoneAuthNumberCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String name, String phoneNumber});
+}
+
+/// @nodoc
+class __$$ReservationFourthRequestPhoneAuthNumberCopyWithImpl<$Res>
+    extends _$ReservationFourthEventCopyWithImpl<$Res,
+        _$ReservationFourthRequestPhoneAuthNumber>
+    implements _$$ReservationFourthRequestPhoneAuthNumberCopyWith<$Res> {
+  __$$ReservationFourthRequestPhoneAuthNumberCopyWithImpl(
+      _$ReservationFourthRequestPhoneAuthNumber _value,
+      $Res Function(_$ReservationFourthRequestPhoneAuthNumber) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? phoneNumber = null,
+  }) {
+    return _then(_$ReservationFourthRequestPhoneAuthNumber(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      phoneNumber: null == phoneNumber
+          ? _value.phoneNumber
+          : phoneNumber // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ReservationFourthRequestPhoneAuthNumber
+    implements ReservationFourthRequestPhoneAuthNumber {
+  const _$ReservationFourthRequestPhoneAuthNumber(
+      {required this.name, required this.phoneNumber});
+
+  @override
+  final String name;
+  @override
+  final String phoneNumber;
+
+  @override
+  String toString() {
+    return 'ReservationFourthEvent.requestPhoneAuthNumber(name: $name, phoneNumber: $phoneNumber)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReservationFourthRequestPhoneAuthNumber &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.phoneNumber, phoneNumber) ||
+                other.phoneNumber == phoneNumber));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, name, phoneNumber);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ReservationFourthRequestPhoneAuthNumberCopyWith<
+          _$ReservationFourthRequestPhoneAuthNumber>
+      get copyWith => __$$ReservationFourthRequestPhoneAuthNumberCopyWithImpl<
+          _$ReservationFourthRequestPhoneAuthNumber>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String name, String phoneNumber)
+        requestPhoneAuthNumber,
+    required TResult Function(String authCode) requestPhoneAuthNumberCheck,
+  }) {
+    return requestPhoneAuthNumber(name, phoneNumber);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String name, String phoneNumber)? requestPhoneAuthNumber,
+    TResult? Function(String authCode)? requestPhoneAuthNumberCheck,
+  }) {
+    return requestPhoneAuthNumber?.call(name, phoneNumber);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String name, String phoneNumber)? requestPhoneAuthNumber,
+    TResult Function(String authCode)? requestPhoneAuthNumberCheck,
+    required TResult orElse(),
+  }) {
+    if (requestPhoneAuthNumber != null) {
+      return requestPhoneAuthNumber(name, phoneNumber);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ReservationFourthRequestPhoneAuthNumber value)
+        requestPhoneAuthNumber,
+    required TResult Function(ReservationFourthRequestPhoneAuthCheck value)
+        requestPhoneAuthNumberCheck,
+  }) {
+    return requestPhoneAuthNumber(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ReservationFourthRequestPhoneAuthNumber value)?
+        requestPhoneAuthNumber,
+    TResult? Function(ReservationFourthRequestPhoneAuthCheck value)?
+        requestPhoneAuthNumberCheck,
+  }) {
+    return requestPhoneAuthNumber?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ReservationFourthRequestPhoneAuthNumber value)?
+        requestPhoneAuthNumber,
+    TResult Function(ReservationFourthRequestPhoneAuthCheck value)?
+        requestPhoneAuthNumberCheck,
+    required TResult orElse(),
+  }) {
+    if (requestPhoneAuthNumber != null) {
+      return requestPhoneAuthNumber(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ReservationFourthRequestPhoneAuthNumber
+    implements ReservationFourthEvent {
+  const factory ReservationFourthRequestPhoneAuthNumber(
+          {required final String name, required final String phoneNumber}) =
+      _$ReservationFourthRequestPhoneAuthNumber;
+
+  String get name;
+  String get phoneNumber;
+  @JsonKey(ignore: true)
+  _$$ReservationFourthRequestPhoneAuthNumberCopyWith<
+          _$ReservationFourthRequestPhoneAuthNumber>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ReservationFourthRequestPhoneAuthCheckCopyWith<$Res> {
+  factory _$$ReservationFourthRequestPhoneAuthCheckCopyWith(
+          _$ReservationFourthRequestPhoneAuthCheck value,
+          $Res Function(_$ReservationFourthRequestPhoneAuthCheck) then) =
+      __$$ReservationFourthRequestPhoneAuthCheckCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String authCode});
+}
+
+/// @nodoc
+class __$$ReservationFourthRequestPhoneAuthCheckCopyWithImpl<$Res>
+    extends _$ReservationFourthEventCopyWithImpl<$Res,
+        _$ReservationFourthRequestPhoneAuthCheck>
+    implements _$$ReservationFourthRequestPhoneAuthCheckCopyWith<$Res> {
+  __$$ReservationFourthRequestPhoneAuthCheckCopyWithImpl(
+      _$ReservationFourthRequestPhoneAuthCheck _value,
+      $Res Function(_$ReservationFourthRequestPhoneAuthCheck) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? authCode = null,
+  }) {
+    return _then(_$ReservationFourthRequestPhoneAuthCheck(
+      authCode: null == authCode
+          ? _value.authCode
+          : authCode // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ReservationFourthRequestPhoneAuthCheck
+    implements ReservationFourthRequestPhoneAuthCheck {
+  const _$ReservationFourthRequestPhoneAuthCheck({required this.authCode});
+
+  @override
+  final String authCode;
+
+  @override
+  String toString() {
+    return 'ReservationFourthEvent.requestPhoneAuthNumberCheck(authCode: $authCode)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReservationFourthRequestPhoneAuthCheck &&
+            (identical(other.authCode, authCode) ||
+                other.authCode == authCode));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, authCode);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ReservationFourthRequestPhoneAuthCheckCopyWith<
+          _$ReservationFourthRequestPhoneAuthCheck>
+      get copyWith => __$$ReservationFourthRequestPhoneAuthCheckCopyWithImpl<
+          _$ReservationFourthRequestPhoneAuthCheck>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String name, String phoneNumber)
+        requestPhoneAuthNumber,
+    required TResult Function(String authCode) requestPhoneAuthNumberCheck,
+  }) {
+    return requestPhoneAuthNumberCheck(authCode);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String name, String phoneNumber)? requestPhoneAuthNumber,
+    TResult? Function(String authCode)? requestPhoneAuthNumberCheck,
+  }) {
+    return requestPhoneAuthNumberCheck?.call(authCode);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String name, String phoneNumber)? requestPhoneAuthNumber,
+    TResult Function(String authCode)? requestPhoneAuthNumberCheck,
+    required TResult orElse(),
+  }) {
+    if (requestPhoneAuthNumberCheck != null) {
+      return requestPhoneAuthNumberCheck(authCode);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ReservationFourthRequestPhoneAuthNumber value)
+        requestPhoneAuthNumber,
+    required TResult Function(ReservationFourthRequestPhoneAuthCheck value)
+        requestPhoneAuthNumberCheck,
+  }) {
+    return requestPhoneAuthNumberCheck(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ReservationFourthRequestPhoneAuthNumber value)?
+        requestPhoneAuthNumber,
+    TResult? Function(ReservationFourthRequestPhoneAuthCheck value)?
+        requestPhoneAuthNumberCheck,
+  }) {
+    return requestPhoneAuthNumberCheck?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ReservationFourthRequestPhoneAuthNumber value)?
+        requestPhoneAuthNumber,
+    TResult Function(ReservationFourthRequestPhoneAuthCheck value)?
+        requestPhoneAuthNumberCheck,
+    required TResult orElse(),
+  }) {
+    if (requestPhoneAuthNumberCheck != null) {
+      return requestPhoneAuthNumberCheck(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ReservationFourthRequestPhoneAuthCheck
+    implements ReservationFourthEvent {
+  const factory ReservationFourthRequestPhoneAuthCheck(
+          {required final String authCode}) =
+      _$ReservationFourthRequestPhoneAuthCheck;
+
+  String get authCode;
+  @JsonKey(ignore: true)
+  _$$ReservationFourthRequestPhoneAuthCheckCopyWith<
+          _$ReservationFourthRequestPhoneAuthCheck>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$ReservationFourthState {
+  RequestAuthNumberStatus get reqAuthNumberStatus =>
+      throw _privateConstructorUsedError;
+  CheckAuthNumberStatus get checkAuthNumberStatus =>
+      throw _privateConstructorUsedError;
+  bool get isRequestSuccess => throw _privateConstructorUsedError;
+  bool get isCheckSuccess => throw _privateConstructorUsedError;
+  String get name => throw _privateConstructorUsedError;
+  String get phoneNumber => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ReservationFourthStateCopyWith<ReservationFourthState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReservationFourthStateCopyWith<$Res> {
+  factory $ReservationFourthStateCopyWith(ReservationFourthState value,
+          $Res Function(ReservationFourthState) then) =
+      _$ReservationFourthStateCopyWithImpl<$Res, ReservationFourthState>;
+  @useResult
+  $Res call(
+      {RequestAuthNumberStatus reqAuthNumberStatus,
+      CheckAuthNumberStatus checkAuthNumberStatus,
+      bool isRequestSuccess,
+      bool isCheckSuccess,
+      String name,
+      String phoneNumber});
+}
+
+/// @nodoc
+class _$ReservationFourthStateCopyWithImpl<$Res,
+        $Val extends ReservationFourthState>
+    implements $ReservationFourthStateCopyWith<$Res> {
+  _$ReservationFourthStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? reqAuthNumberStatus = null,
+    Object? checkAuthNumberStatus = null,
+    Object? isRequestSuccess = null,
+    Object? isCheckSuccess = null,
+    Object? name = null,
+    Object? phoneNumber = null,
+  }) {
+    return _then(_value.copyWith(
+      reqAuthNumberStatus: null == reqAuthNumberStatus
+          ? _value.reqAuthNumberStatus
+          : reqAuthNumberStatus // ignore: cast_nullable_to_non_nullable
+              as RequestAuthNumberStatus,
+      checkAuthNumberStatus: null == checkAuthNumberStatus
+          ? _value.checkAuthNumberStatus
+          : checkAuthNumberStatus // ignore: cast_nullable_to_non_nullable
+              as CheckAuthNumberStatus,
+      isRequestSuccess: null == isRequestSuccess
+          ? _value.isRequestSuccess
+          : isRequestSuccess // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isCheckSuccess: null == isCheckSuccess
+          ? _value.isCheckSuccess
+          : isCheckSuccess // ignore: cast_nullable_to_non_nullable
+              as bool,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      phoneNumber: null == phoneNumber
+          ? _value.phoneNumber
+          : phoneNumber // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InitialCopyWith<$Res>
+    implements $ReservationFourthStateCopyWith<$Res> {
+  factory _$$InitialCopyWith(_$Initial value, $Res Function(_$Initial) then) =
+      __$$InitialCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {RequestAuthNumberStatus reqAuthNumberStatus,
+      CheckAuthNumberStatus checkAuthNumberStatus,
+      bool isRequestSuccess,
+      bool isCheckSuccess,
+      String name,
+      String phoneNumber});
+}
+
+/// @nodoc
+class __$$InitialCopyWithImpl<$Res>
+    extends _$ReservationFourthStateCopyWithImpl<$Res, _$Initial>
+    implements _$$InitialCopyWith<$Res> {
+  __$$InitialCopyWithImpl(_$Initial _value, $Res Function(_$Initial) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? reqAuthNumberStatus = null,
+    Object? checkAuthNumberStatus = null,
+    Object? isRequestSuccess = null,
+    Object? isCheckSuccess = null,
+    Object? name = null,
+    Object? phoneNumber = null,
+  }) {
+    return _then(_$Initial(
+      reqAuthNumberStatus: null == reqAuthNumberStatus
+          ? _value.reqAuthNumberStatus
+          : reqAuthNumberStatus // ignore: cast_nullable_to_non_nullable
+              as RequestAuthNumberStatus,
+      checkAuthNumberStatus: null == checkAuthNumberStatus
+          ? _value.checkAuthNumberStatus
+          : checkAuthNumberStatus // ignore: cast_nullable_to_non_nullable
+              as CheckAuthNumberStatus,
+      isRequestSuccess: null == isRequestSuccess
+          ? _value.isRequestSuccess
+          : isRequestSuccess // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isCheckSuccess: null == isCheckSuccess
+          ? _value.isCheckSuccess
+          : isCheckSuccess // ignore: cast_nullable_to_non_nullable
+              as bool,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      phoneNumber: null == phoneNumber
+          ? _value.phoneNumber
+          : phoneNumber // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$Initial implements Initial {
+  const _$Initial(
+      {this.reqAuthNumberStatus = RequestAuthNumberStatus.initial,
+      this.checkAuthNumberStatus = CheckAuthNumberStatus.initial,
+      this.isRequestSuccess = false,
+      this.isCheckSuccess = false,
+      this.name = '',
+      this.phoneNumber = ''});
+
+  @override
+  @JsonKey()
+  final RequestAuthNumberStatus reqAuthNumberStatus;
+  @override
+  @JsonKey()
+  final CheckAuthNumberStatus checkAuthNumberStatus;
+  @override
+  @JsonKey()
+  final bool isRequestSuccess;
+  @override
+  @JsonKey()
+  final bool isCheckSuccess;
+  @override
+  @JsonKey()
+  final String name;
+  @override
+  @JsonKey()
+  final String phoneNumber;
+
+  @override
+  String toString() {
+    return 'ReservationFourthState(reqAuthNumberStatus: $reqAuthNumberStatus, checkAuthNumberStatus: $checkAuthNumberStatus, isRequestSuccess: $isRequestSuccess, isCheckSuccess: $isCheckSuccess, name: $name, phoneNumber: $phoneNumber)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$Initial &&
+            (identical(other.reqAuthNumberStatus, reqAuthNumberStatus) ||
+                other.reqAuthNumberStatus == reqAuthNumberStatus) &&
+            (identical(other.checkAuthNumberStatus, checkAuthNumberStatus) ||
+                other.checkAuthNumberStatus == checkAuthNumberStatus) &&
+            (identical(other.isRequestSuccess, isRequestSuccess) ||
+                other.isRequestSuccess == isRequestSuccess) &&
+            (identical(other.isCheckSuccess, isCheckSuccess) ||
+                other.isCheckSuccess == isCheckSuccess) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.phoneNumber, phoneNumber) ||
+                other.phoneNumber == phoneNumber));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      reqAuthNumberStatus,
+      checkAuthNumberStatus,
+      isRequestSuccess,
+      isCheckSuccess,
+      name,
+      phoneNumber);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InitialCopyWith<_$Initial> get copyWith =>
+      __$$InitialCopyWithImpl<_$Initial>(this, _$identity);
+}
+
+abstract class Initial implements ReservationFourthState {
+  const factory Initial(
+      {final RequestAuthNumberStatus reqAuthNumberStatus,
+      final CheckAuthNumberStatus checkAuthNumberStatus,
+      final bool isRequestSuccess,
+      final bool isCheckSuccess,
+      final String name,
+      final String phoneNumber}) = _$Initial;
+
+  @override
+  RequestAuthNumberStatus get reqAuthNumberStatus;
+  @override
+  CheckAuthNumberStatus get checkAuthNumberStatus;
+  @override
+  bool get isRequestSuccess;
+  @override
+  bool get isCheckSuccess;
+  @override
+  String get name;
+  @override
+  String get phoneNumber;
+  @override
+  @JsonKey(ignore: true)
+  _$$InitialCopyWith<_$Initial> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/presentation/views/reservation/bloc/fourth/reservation_fourth_event.dart
+++ b/lib/presentation/views/reservation/bloc/fourth/reservation_fourth_event.dart
@@ -1,16 +1,13 @@
 part of 'reservation_fourth_bloc.dart';
 
-abstract class ReservationFourthEvent extends Equatable {
-  const ReservationFourthEvent();
-}
+@freezed
+class ReservationFourthEvent with _$ReservationFourthEvent {
+  const factory ReservationFourthEvent.requestPhoneAuthNumber({
+    required String name,
+    required String phoneNumber,
+  }) = ReservationFourthRequestPhoneAuthNumber;
 
-/// 📌 인증번호를 문자를 보내는 API Event
-class ReservationFourthGetPhoneAuthNumberEvent extends ReservationFourthEvent {
-  const ReservationFourthGetPhoneAuthNumberEvent();
-
-  @override
-  List<Object?> get props => [];
-
-  @override
-  bool? get stringify => false;
+  const factory ReservationFourthEvent.requestPhoneAuthNumberCheck({
+    required String authCode,
+  }) = ReservationFourthRequestPhoneAuthCheck;
 }

--- a/lib/presentation/views/reservation/bloc/fourth/reservation_fourth_event.dart
+++ b/lib/presentation/views/reservation/bloc/fourth/reservation_fourth_event.dart
@@ -1,0 +1,16 @@
+part of 'reservation_fourth_bloc.dart';
+
+abstract class ReservationFourthEvent extends Equatable {
+  const ReservationFourthEvent();
+}
+
+/// 📌 인증번호를 문자를 보내는 API Event
+class ReservationFourthGetPhoneAuthNumberEvent extends ReservationFourthEvent {
+  const ReservationFourthGetPhoneAuthNumberEvent();
+
+  @override
+  List<Object?> get props => [];
+
+  @override
+  bool? get stringify => false;
+}

--- a/lib/presentation/views/reservation/bloc/fourth/reservation_fourth_state.dart
+++ b/lib/presentation/views/reservation/bloc/fourth/reservation_fourth_state.dart
@@ -1,77 +1,27 @@
 part of 'reservation_fourth_bloc.dart';
 
-enum SentMessageStateType {
-  init,
+enum RequestAuthNumberStatus {
+  initial,
   loading,
   success,
-  failure,
+  error,
 }
 
-enum CheckPhoneAuthType {
-  init,
+enum CheckAuthNumberStatus {
+  initial,
   loading,
   success,
-  failure,
+  error,
 }
 
-class ReservationFourthState extends Equatable {
-  final String name;
-  final String phoneNumber;
-
-  final SentMessageStateType sendMessageStateType;
-  final bool isSentMessageSuccessfully; // 인증 문자 발송 성공 여부
-
-  final CheckPhoneAuthType checkPhoneAuthType;
-  final bool isGrantedCheck; // 인증 문자 체크 성공 여부
-
-  const ReservationFourthState({
-    required this.name,
-    required this.phoneNumber,
-    required this.sendMessageStateType,
-    required this.isSentMessageSuccessfully,
-    required this.isGrantedCheck,
-    required this.checkPhoneAuthType,
-  });
-
-  factory ReservationFourthState.initial() {
-    return ReservationFourthState(
-      name: '',
-      phoneNumber: '',
-      sendMessageStateType: SentMessageStateType.init,
-      isSentMessageSuccessfully: false,
-      checkPhoneAuthType: CheckPhoneAuthType.init,
-      isGrantedCheck: false,
-    );
-  }
-
-  ReservationFourthState copyWith({
-    String? name,
-    String? phoneNumber,
-    SentMessageStateType? sendMessageStateType,
-    bool? isSentMessageSuccessfully,
-    CheckPhoneAuthType? checkPhoneAuthType,
-    bool? isGrantedCheck,
-  }) {
-    return ReservationFourthState(
-      name: name ?? this.name,
-      phoneNumber: phoneNumber ?? this.phoneNumber,
-      sendMessageStateType: sendMessageStateType ?? this.sendMessageStateType,
-      isSentMessageSuccessfully: isSentMessageSuccessfully ?? this.isSentMessageSuccessfully,
-      checkPhoneAuthType: checkPhoneAuthType ?? this.checkPhoneAuthType,
-      isGrantedCheck: isGrantedCheck ?? this.isGrantedCheck,
-    );
-  }
-
-  @override
-  List<Object?> get props => [
-        name,
-        phoneNumber,
-        sendMessageStateType,
-        isSentMessageSuccessfully,
-        checkPhoneAuthType,
-        isGrantedCheck,
-      ];
-
-  @override
-  bool? get stringify => true;
+@freezed
+class ReservationFourthState with _$ReservationFourthState {
+  const factory ReservationFourthState({
+    @Default(RequestAuthNumberStatus.initial) RequestAuthNumberStatus reqAuthNumberStatus,
+    @Default(CheckAuthNumberStatus.initial) CheckAuthNumberStatus checkAuthNumberStatus,
+    @Default(false) bool isRequestSuccess,
+    @Default(false) bool isCheckSuccess,
+    @Default('') String name,
+    @Default('') String phoneNumber,
+  }) = Initial;
 }

--- a/lib/presentation/views/reservation/bloc/fourth/reservation_fourth_state.dart
+++ b/lib/presentation/views/reservation/bloc/fourth/reservation_fourth_state.dart
@@ -1,0 +1,77 @@
+part of 'reservation_fourth_bloc.dart';
+
+enum SentMessageStateType {
+  init,
+  loading,
+  success,
+  failure,
+}
+
+enum CheckPhoneAuthType {
+  init,
+  loading,
+  success,
+  failure,
+}
+
+class ReservationFourthState extends Equatable {
+  final String name;
+  final String phoneNumber;
+
+  final SentMessageStateType sendMessageStateType;
+  final bool isSentMessageSuccessfully; // 인증 문자 발송 성공 여부
+
+  final CheckPhoneAuthType checkPhoneAuthType;
+  final bool isGrantedCheck; // 인증 문자 체크 성공 여부
+
+  const ReservationFourthState({
+    required this.name,
+    required this.phoneNumber,
+    required this.sendMessageStateType,
+    required this.isSentMessageSuccessfully,
+    required this.isGrantedCheck,
+    required this.checkPhoneAuthType,
+  });
+
+  factory ReservationFourthState.initial() {
+    return ReservationFourthState(
+      name: '',
+      phoneNumber: '',
+      sendMessageStateType: SentMessageStateType.init,
+      isSentMessageSuccessfully: false,
+      checkPhoneAuthType: CheckPhoneAuthType.init,
+      isGrantedCheck: false,
+    );
+  }
+
+  ReservationFourthState copyWith({
+    String? name,
+    String? phoneNumber,
+    SentMessageStateType? sendMessageStateType,
+    bool? isSentMessageSuccessfully,
+    CheckPhoneAuthType? checkPhoneAuthType,
+    bool? isGrantedCheck,
+  }) {
+    return ReservationFourthState(
+      name: name ?? this.name,
+      phoneNumber: phoneNumber ?? this.phoneNumber,
+      sendMessageStateType: sendMessageStateType ?? this.sendMessageStateType,
+      isSentMessageSuccessfully: isSentMessageSuccessfully ?? this.isSentMessageSuccessfully,
+      checkPhoneAuthType: checkPhoneAuthType ?? this.checkPhoneAuthType,
+      isGrantedCheck: isGrantedCheck ?? this.isGrantedCheck,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        name,
+        phoneNumber,
+        sendMessageStateType,
+        isSentMessageSuccessfully,
+        checkPhoneAuthType,
+        isGrantedCheck,
+      ];
+
+  @override
+  bool? get stringify => true;
+}

--- a/lib/presentation/views/reservation/bloc/reservation_bloc.dart
+++ b/lib/presentation/views/reservation/bloc/reservation_bloc.dart
@@ -33,6 +33,9 @@ class ReservationBloc extends Bloc<ReservationEvent, ReservationState> {
     on<ReservationTermAllAgreeEvent>(
       (event, emit) => _setTermIsAllAgree(event, emit),
     );
+    on<ReservationUserAuthEvent>(
+      (event, emit) => _setIsCheckedAuth(event, emit),
+    );
   }
 
   void _setProcessCurrentPosition(
@@ -121,5 +124,12 @@ class ReservationBloc extends Bloc<ReservationEvent, ReservationState> {
     Emitter<ReservationState> emit,
   ) {
     emit(state.copyWith(termIsAllAgree: event.isAllSelected));
+  }
+
+  void _setIsCheckedAuth(
+    ReservationUserAuthEvent event,
+    Emitter<ReservationState> emit,
+  ) {
+    emit(state.copyWith(isCheckedAuth: event.isCheckedAuth));
   }
 }

--- a/lib/presentation/views/reservation/bloc/reservation_event.dart
+++ b/lib/presentation/views/reservation/bloc/reservation_event.dart
@@ -98,3 +98,14 @@ class ReservationTermAllAgreeEvent extends ReservationEvent {
   @override
   bool? get stringify => false;
 }
+
+class ReservationUserAuthEvent extends ReservationEvent {
+  final bool isCheckedAuth;
+  const ReservationUserAuthEvent({required this.isCheckedAuth});
+
+  @override
+  List<Object?> get props => [isCheckedAuth];
+
+  @override
+  bool? get stringify => false;
+}

--- a/lib/presentation/views/reservation/bloc/reservation_state.dart
+++ b/lib/presentation/views/reservation/bloc/reservation_state.dart
@@ -8,6 +8,7 @@ class ReservationState extends Equatable {
   final List<SeatType> selectedSeats; // 선택된 좌석 List
   final int realUserCount; // 선택된 예약인원수 [실제 예약인원수]
   final bool termIsAllAgree; // 약관 동의 - 전체 동의 했는지 여부
+  final bool isCheckedAuth; // 본인 인증 여부
 
   const ReservationState({
     required this.currentPosition,
@@ -17,6 +18,7 @@ class ReservationState extends Equatable {
     required this.selectedSeats,
     required this.realUserCount,
     required this.termIsAllAgree,
+    required this.isCheckedAuth,
   });
 
   factory ReservationState.initial() {
@@ -28,6 +30,7 @@ class ReservationState extends Equatable {
       selectedSeats: [],
       realUserCount: 1,
       termIsAllAgree: false,
+      isCheckedAuth: false,
     );
   }
 
@@ -39,6 +42,7 @@ class ReservationState extends Equatable {
     List<SeatType>? selectedSeats,
     int? realUserCount,
     bool? termIsAllAgree,
+    bool? isCheckedAuth,
   }) {
     return ReservationState(
       currentPosition: currentPosition ?? this.currentPosition,
@@ -48,6 +52,7 @@ class ReservationState extends Equatable {
       selectedSeats: selectedSeats ?? this.selectedSeats,
       realUserCount: realUserCount ?? this.realUserCount,
       termIsAllAgree: termIsAllAgree ?? this.termIsAllAgree,
+      isCheckedAuth: isCheckedAuth ?? this.isCheckedAuth,
     );
   }
 
@@ -60,6 +65,7 @@ class ReservationState extends Equatable {
         selectedSeats,
         realUserCount,
         termIsAllAgree,
+        isCheckedAuth,
       ];
 
   @override

--- a/lib/presentation/views/reservation/reservation_screen.dart
+++ b/lib/presentation/views/reservation/reservation_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reservation_app/di/dependency_inection_graph.dart';
 import 'package:reservation_app/presentation/utils/color_constants.dart';
+import 'package:reservation_app/presentation/views/reservation/bloc/fourth/reservation_fourth_bloc.dart';
 import 'package:reservation_app/presentation/views/reservation/bloc/reservation_bloc.dart';
 import 'package:reservation_app/presentation/views/reservation/bloc/second/reservation_second_bloc.dart';
 import 'package:reservation_app/presentation/views/reservation/bloc/third/reservation_third_bloc.dart';
@@ -41,13 +42,18 @@ class _ReservationScreenState extends State<ReservationScreen> {
           create: (context) => locator.get<ReservationSecondBloc>(),
         ),
         BlocProvider<ReservationThirdBloc>(
-            create: (context) => locator.get<ReservationThirdBloc>(),
+          create: (context) => locator.get<ReservationThirdBloc>(),
+        ),
+        BlocProvider<ReservationFourthBloc>(
+          create: (context) => locator.get<ReservationFourthBloc>(),
         ),
       ],
       child: Scaffold(
         backgroundColor: Colors.white,
         appBar: ReservationAppBarWidget(),
-        body: SafeArea(child: ReservationProcessView(),),
+        body: SafeArea(
+          child: ReservationProcessView(),
+        ),
         floatingActionButton: CloseFloatingActionWidget(),
       ),
     );

--- a/lib/presentation/views/reservation/view/reservation_fourth_process_view.dart
+++ b/lib/presentation/views/reservation/view/reservation_fourth_process_view.dart
@@ -136,20 +136,29 @@ class _ReservationFourthProcessViewState
               return;
             }
 
-            if (state.checkAuthNumberStatus == CheckAuthNumberStatus.success &&
-                state.isCheckSuccess) {
-              SnackBarUtils.showCustomSnackBar(context, "인증 완료되었습니다.");
+            if (state.checkAuthNumberStatus == CheckAuthNumberStatus.success) {
+              if (state.isCheckSuccess) {
+                SnackBarUtils.showCustomSnackBar(context, "인증 완료되었습니다.");
 
-              final allFocus = FocusScope.of(context);
-              if (allFocus.hasFocus) {
-                allFocus.unfocus();
+                final allFocus = FocusScope.of(context);
+                if (allFocus.hasFocus) {
+                  allFocus.unfocus();
+                }
+
+                _stopTimer();
+                reservationBloc.add(
+                  ReservationUserAuthEvent(isCheckedAuth: true),
+                );
+              } else {
+                SnackBarUtils.showCustomSnackBar(
+                  context,
+                  "인증에 실패하였습니다. 다시 시도해주세요.",
+                );
+                reservationBloc.add(
+                  ReservationUserAuthEvent(isCheckedAuth: false),
+                );
               }
-
-              _stopTimer();
-              reservationBloc.add(
-                ReservationUserAuthEvent(isCheckedAuth: true),
-              );
-            } else {
+            } else if (state.checkAuthNumberStatus == CheckAuthNumberStatus.error) {
               SnackBarUtils.showCustomSnackBar(
                 context,
                 "인증에 실패하였습니다. 다시 시도해주세요.",

--- a/lib/presentation/views/reservation/view/reservation_fourth_process_view.dart
+++ b/lib/presentation/views/reservation/view/reservation_fourth_process_view.dart
@@ -1,15 +1,178 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reservation_app/presentation/utils/color_constants.dart';
+import 'package:reservation_app/presentation/utils/text_utils.dart';
+import 'package:reservation_app/presentation/views/reservation/bloc/fourth/reservation_fourth_bloc.dart';
 
 class ReservationFourthProcessView extends StatefulWidget {
   const ReservationFourthProcessView({Key? key}) : super(key: key);
 
   @override
-  State<ReservationFourthProcessView> createState() => _ReservationFourthProcessViewState();
+  State<ReservationFourthProcessView> createState() =>
+      _ReservationFourthProcessViewState();
 }
 
-class _ReservationFourthProcessViewState extends State<ReservationFourthProcessView> {
+class _ReservationFourthProcessViewState
+    extends State<ReservationFourthProcessView> {
+  final nameController = TextEditingController();
+  final phoneController = TextEditingController();
+
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  void dispose() {
+    nameController.dispose();
+    phoneController.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
-    return const Center(child: Text("좌석 선택"),);
+    final reservationFourthBloc = context.read<ReservationFourthBloc>();
+
+    return Expanded(
+      child: Container(
+        margin: EdgeInsets.only(
+          top: 30.0,
+          left: 30.0,
+          right: 30.0,
+          bottom: 20.0,
+        ),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                key: const Key('nameTextField'),
+                controller: nameController,
+                autovalidateMode: AutovalidateMode.always,
+                textInputAction: TextInputAction.done,
+                validator: (value) {
+                  final text = value;
+                  if (text == null || text.isEmpty || text.length < 2) {
+                    return '2~4자 이내의 문자';
+                  }
+
+                  if (text.isNotEmpty && !TextUtils.isNameValid(text)) {
+                    return '2~4자 이내로 제대로된 성함을 입력해 주세요.';
+                  }
+
+                  return null;
+                },
+                maxLength: 4,
+                inputFormatters: [
+                  // 한글 자판만 허용 (숫자, 영어, 이모티콘 다 안됨)
+                  FilteringTextInputFormatter.allow(RegExp('[ㄱ-ㅣ가-힣]*')),
+                ],
+                keyboardType: TextInputType.name,
+                decoration: InputDecoration(
+                  suffixIcon: InkWell(
+                    onTap: () => nameController.clear(),
+                    child: Icon(
+                      Icons.cancel,
+                      color: ColorsConstants.boldColor,
+                      size: 20,
+                    ),
+                  ),
+                  prefixIcon: Icon(Icons.person),
+                  prefixIconColor: ColorsConstants.strokeColor,
+                  helperText: "2~4자 이내의 문자",
+                  helperStyle: TextStyle(
+                    color: ColorsConstants.strokeColor,
+                  ),
+                  iconColor: ColorsConstants.strokeColor,
+                  hintText: '예약자 성함을 입력해주세요.',
+                  hintStyle: TextStyle(
+                    color: ColorsConstants.textHint,
+                    fontSize: 15,
+                  ),
+                  labelText: '예약자 성함',
+                  labelStyle: TextStyle(
+                    color: ColorsConstants.strokeColor,
+                    fontSize: 14,
+                  ),
+                  errorBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.all(Radius.circular(10)),
+                    borderSide: BorderSide(
+                      color: ColorsConstants.primary,
+                      width: 1,
+                    ),
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.all(Radius.circular(10)),
+                    borderSide: BorderSide(
+                      color: ColorsConstants.primaryButtonBackgroundDisabled,
+                      width: 1,
+                    ),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.all(Radius.circular(10)),
+                    borderSide: BorderSide(
+                      color: ColorsConstants.strokeColor,
+                      width: 1,
+                    ),
+                  ),
+                  contentPadding: EdgeInsets.symmetric(vertical: 10),
+                ),
+                style: TextStyle(
+                  color: ColorsConstants.boldColor,
+                  fontSize: 15,
+                ),
+              ),
+              Container(constraints: const BoxConstraints.expand(height: 25.0)),
+              TextFormField(
+                key: const Key('phoneNumberTextField'),
+                controller: phoneController,
+                maxLength: 11,
+                inputFormatters: [
+                  // 숫자만 자판만 허용(한글, 영어, 이모티콘 다 안됨)
+                  FilteringTextInputFormatter.allow(RegExp(r'[0-9]')),
+                ],
+                keyboardType: TextInputType.number,
+                decoration: const InputDecoration(
+                  helperText: "10~11자 이내의 숫자",
+                  helperStyle: TextStyle(
+                    color: ColorsConstants.guideText,
+                  ),
+                  prefixIcon: Icon(Icons.phone_enabled),
+                  prefixIconColor: ColorsConstants.strokeColor,
+                  iconColor: ColorsConstants.strokeColor,
+                  hintText: '예약자 휴대폰 번호를 입력해주세요.',
+                  hintStyle: TextStyle(
+                    color: ColorsConstants.textHint,
+                    fontSize: 15,
+                  ),
+                  labelText: '예약자 휴대폰 번호',
+                  labelStyle: TextStyle(
+                    color: ColorsConstants.strokeColor,
+                    fontSize: 14,
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.all(Radius.circular(10)),
+                    borderSide: BorderSide(
+                      color: ColorsConstants.primaryButtonBackgroundDisabled,
+                      width: 1,
+                    ),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.all(Radius.circular(10)),
+                    borderSide: BorderSide(
+                      color: ColorsConstants.strokeColor,
+                      width: 1,
+                    ),
+                  ),
+                  contentPadding: EdgeInsets.symmetric(vertical: 10),
+                ),
+                style: TextStyle(
+                  color: ColorsConstants.boldColor,
+                  fontSize: 15,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/presentation/views/reservation/view/reservation_fourth_process_view.dart
+++ b/lib/presentation/views/reservation/view/reservation_fourth_process_view.dart
@@ -1,9 +1,15 @@
+import 'dart:async';
+
+import 'package:animated_text_kit/animated_text_kit.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reservation_app/presentation/utils/color_constants.dart';
+import 'package:reservation_app/presentation/utils/date_time_utils.dart';
+import 'package:reservation_app/presentation/utils/snack_bar_utils.dart';
 import 'package:reservation_app/presentation/utils/text_utils.dart';
 import 'package:reservation_app/presentation/views/reservation/bloc/fourth/reservation_fourth_bloc.dart';
+import 'package:reservation_app/presentation/views/reservation/bloc/reservation_bloc.dart';
 
 class ReservationFourthProcessView extends StatefulWidget {
   const ReservationFourthProcessView({Key? key}) : super(key: key);
@@ -15,161 +21,660 @@ class ReservationFourthProcessView extends StatefulWidget {
 
 class _ReservationFourthProcessViewState
     extends State<ReservationFourthProcessView> {
-  final nameController = TextEditingController();
-  final phoneController = TextEditingController();
-
   final _formKey = GlobalKey<FormState>();
+  final _nameKey = GlobalKey<FormFieldState>();
+  final _phoneNumberKey = GlobalKey<FormFieldState>();
+  final _authPhoneNumberKey = GlobalKey<FormFieldState>();
+
+  final _nameController = TextEditingController();
+  final _phoneController = TextEditingController();
+  final _authNumberController = TextEditingController();
+
+  final List<FocusNode> _focusNodes = List.generate(3, (index) => FocusNode());
+
+  int _durationInSeconds = 3 * 60; // 5 분에서 시작
+  Timer? _timer;
+
+  bool _isNameValidate = false;
+  bool _isPhoneNumberValidate = false;
+  bool _isAuthCodeValidate = false;
+
+  bool _isFocusInput(int index) {
+    return _focusNodes[index].hasFocus;
+  }
+
+  void _onFocusOutInput(int index) {
+    if (_isFocusInput(index)) {
+      _focusNodes[index].unfocus();
+    }
+  }
+
+  void _onFocusInput(BuildContext context, int index) {
+    if (!_isFocusInput(index)) {
+      FocusScope.of(context).requestFocus(_focusNodes[index]);
+    }
+  }
+
+  void _startTimer() {
+    _timer = Timer.periodic(Duration(seconds: 1), (timer) {
+      setState(() {
+        // 타이머 진행 시간을 업데이트하여 화면에 반영
+        _durationInSeconds--;
+
+        if (_durationInSeconds == 0) {
+          _stopTimer();
+          // 타이머가 완료되었을 때 동작
+          SnackBarUtils.showCustomSnackBar(
+            context,
+            "인증번호가 만료되었습니다. 인증번호를 재발급 해주세요.",
+          );
+        }
+      });
+    });
+  }
+
+  void _stopTimer() {
+    final currentTimer = _timer;
+    if (currentTimer != null && currentTimer.isActive) {
+      currentTimer.cancel();
+    }
+  }
+
+  void _restartTimer() {
+    _stopTimer(); // 기존 타이머를 중지
+    setState(() {
+      _durationInSeconds = 3 * 60; // 타이머 시간을 다시 5분으로 설정
+      _timer = null; // _timer 변수를 null 로 초기화
+    });
+    _startTimer(); // 타이머를 다시 시작
+  }
 
   @override
   void dispose() {
-    nameController.dispose();
-    phoneController.dispose();
+    _stopTimer();
+    _nameController.dispose();
+    _phoneController.dispose();
+    _authNumberController.dispose();
+    for (var node in _focusNodes) {
+      node.dispose();
+    }
+
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    final reservationBloc = BlocProvider.of<ReservationBloc>(context);
     final reservationFourthBloc = context.read<ReservationFourthBloc>();
 
     return Expanded(
-      child: Container(
-        margin: EdgeInsets.only(
-          top: 30.0,
-          left: 30.0,
-          right: 30.0,
-          bottom: 20.0,
-        ),
-        child: Form(
-          key: _formKey,
-          child: Column(
-            children: [
-              TextFormField(
-                key: const Key('nameTextField'),
-                controller: nameController,
-                autovalidateMode: AutovalidateMode.always,
-                textInputAction: TextInputAction.done,
-                validator: (value) {
-                  final text = value;
-                  if (text == null || text.isEmpty || text.length < 2) {
-                    return '2~4자 이내의 문자';
-                  }
+      child: GestureDetector(
+        onTap: () {
+          final allFocus = FocusScope.of(context);
+          if (allFocus.hasFocus) {
+            allFocus.unfocus();
+          }
+        },
+        child: BlocListener<ReservationFourthBloc, ReservationFourthState>(
+          listener: (context, state) {
+            if (state.reqAuthNumberStatus == RequestAuthNumberStatus.success &&
+                state.isRequestSuccess) {
+              SnackBarUtils.showCustomSnackBar(context, "인증 번호를 보냈습니다.");
 
-                  if (text.isNotEmpty && !TextUtils.isNameValid(text)) {
-                    return '2~4자 이내로 제대로된 성함을 입력해 주세요.';
-                  }
+              if (_isFocusInput(2)) {
+                _timer == null ? _startTimer() : _restartTimer();
+                return;
+              }
 
-                  return null;
-                },
-                maxLength: 4,
-                inputFormatters: [
-                  // 한글 자판만 허용 (숫자, 영어, 이모티콘 다 안됨)
-                  FilteringTextInputFormatter.allow(RegExp('[ㄱ-ㅣ가-힣]*')),
-                ],
-                keyboardType: TextInputType.name,
-                decoration: InputDecoration(
-                  suffixIcon: InkWell(
-                    onTap: () => nameController.clear(),
-                    child: Icon(
-                      Icons.cancel,
-                      color: ColorsConstants.boldColor,
-                      size: 20,
+              final allFocus = FocusScope.of(context);
+              if (allFocus.hasFocus) {
+                allFocus.unfocus();
+              }
+
+              _onFocusInput(context, 2);
+              _timer == null ? _startTimer() : _restartTimer();
+              return;
+            }
+
+            if (state.checkAuthNumberStatus == CheckAuthNumberStatus.success &&
+                state.isCheckSuccess) {
+              SnackBarUtils.showCustomSnackBar(context, "인증 완료되었습니다.");
+
+              final allFocus = FocusScope.of(context);
+              if (allFocus.hasFocus) {
+                allFocus.unfocus();
+              }
+
+              _stopTimer();
+              reservationBloc.add(
+                ReservationUserAuthEvent(isCheckedAuth: true),
+              );
+            } else {
+              SnackBarUtils.showCustomSnackBar(
+                context,
+                "인증에 실패하였습니다. 다시 시도해주세요.",
+              );
+              reservationBloc.add(
+                ReservationUserAuthEvent(isCheckedAuth: false),
+              );
+            }
+          },
+          child: Container(
+            margin: EdgeInsets.only(
+              top: 20.0,
+              left: 30.0,
+              right: 30.0,
+              bottom: 20.0,
+            ),
+            child: SingleChildScrollView(
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  children: [
+                    Container(
+                      constraints: const BoxConstraints.expand(height: 10),
                     ),
-                  ),
-                  prefixIcon: Icon(Icons.person),
-                  prefixIconColor: ColorsConstants.strokeColor,
-                  helperText: "2~4자 이내의 문자",
-                  helperStyle: TextStyle(
-                    color: ColorsConstants.strokeColor,
-                  ),
-                  iconColor: ColorsConstants.strokeColor,
-                  hintText: '예약자 성함을 입력해주세요.',
-                  hintStyle: TextStyle(
-                    color: ColorsConstants.textHint,
-                    fontSize: 15,
-                  ),
-                  labelText: '예약자 성함',
-                  labelStyle: TextStyle(
-                    color: ColorsConstants.strokeColor,
-                    fontSize: 14,
-                  ),
-                  errorBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.all(Radius.circular(10)),
-                    borderSide: BorderSide(
-                      color: ColorsConstants.primary,
-                      width: 1,
+                    TextFormField(
+                      key: _nameKey,
+                      controller: _nameController,
+                      focusNode: _focusNodes[0],
+                      autovalidateMode: AutovalidateMode.always,
+                      textInputAction: TextInputAction.done,
+                      onFieldSubmitted: (value) {
+                        _onFocusOutInput(0);
+                        if (!_isPhoneNumberValidate) {
+                          _onFocusInput(context, 1);
+                        }
+                      },
+                      onChanged: (value) {
+                        setState(() {
+                          _isNameValidate = value.isNotEmpty &&
+                              value.length > 2 &&
+                              TextUtils.isNameValid(value);
+                        });
+                      },
+                      validator: (value) {
+                        final text = value;
+                        if (text == null || text.isEmpty || text.length < 2) {
+                          return '2~4자 이내의 문자';
+                        }
+
+                        if (text.isNotEmpty && !TextUtils.isNameValid(text)) {
+                          return '2~4자 이내로 제대로된 성함을 입력해 주세요.';
+                        }
+
+                        return null;
+                      },
+                      maxLength: 4,
+                      inputFormatters: [
+                        // 한글 자판만 허용 (숫자, 영어, 이모티콘 다 안됨)
+                        FilteringTextInputFormatter.allow(RegExp('[ㄱ-ㅣ가-힣]*')),
+                      ],
+                      keyboardType: TextInputType.name,
+                      decoration: InputDecoration(
+                        suffixIcon: InkWell(
+                          onTap: () => _nameController.clear(),
+                          child: Icon(
+                            Icons.cancel,
+                            color: ColorsConstants.boldColor,
+                            size: 20,
+                          ),
+                        ),
+                        prefixIcon: Icon(Icons.person),
+                        prefixIconColor: ColorsConstants.strokeColor,
+                        helperText: "2~4자 이내의 문자",
+                        helperStyle: TextStyle(
+                          color: ColorsConstants.strokeColor,
+                        ),
+                        iconColor: ColorsConstants.strokeColor,
+                        hintText: '예약자 성함을 입력해주세요.',
+                        hintStyle: TextStyle(
+                          color: ColorsConstants.textHint,
+                          fontSize: 15,
+                        ),
+                        labelText: '예약자 성함',
+                        labelStyle: TextStyle(
+                          color: ColorsConstants.strokeColor,
+                          fontSize: 14,
+                        ),
+                        focusedErrorBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.all(Radius.circular(10)),
+                          borderSide: BorderSide(
+                            color: ColorsConstants.primary,
+                            width: 1,
+                          ),
+                        ),
+                        errorBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.all(Radius.circular(10)),
+                          borderSide: BorderSide(
+                            color: ColorsConstants.primary,
+                            width: 1,
+                          ),
+                        ),
+                        enabledBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.all(Radius.circular(10)),
+                          borderSide: BorderSide(
+                            color:
+                            ColorsConstants.primaryButtonBackgroundDisabled,
+                            width: 1,
+                          ),
+                        ),
+                        focusedBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.all(Radius.circular(10)),
+                          borderSide: BorderSide(
+                            color: ColorsConstants.strokeColor,
+                            width: 1,
+                          ),
+                        ),
+                        contentPadding: EdgeInsets.symmetric(vertical: 10),
+                      ),
+                      style: TextStyle(
+                        color: ColorsConstants.boldColor,
+                        fontSize: 15,
+                      ),
                     ),
-                  ),
-                  enabledBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.all(Radius.circular(10)),
-                    borderSide: BorderSide(
-                      color: ColorsConstants.primaryButtonBackgroundDisabled,
-                      width: 1,
+                    Container(
+                      constraints: const BoxConstraints.expand(height: 25.0),
                     ),
-                  ),
-                  focusedBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.all(Radius.circular(10)),
-                    borderSide: BorderSide(
-                      color: ColorsConstants.strokeColor,
-                      width: 1,
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Expanded(
+                          flex: 7,
+                          child: TextFormField(
+                            key: _phoneNumberKey,
+                            controller: _phoneController,
+                            focusNode: _focusNodes[1],
+                            autovalidateMode: AutovalidateMode.always,
+                            onChanged: (value) {
+                              setState(() {
+                                _isPhoneNumberValidate = value.isNotEmpty &&
+                                    value.length > 10 &&
+                                    TextUtils.isPhoneNumberValid(value);
+                              });
+                            },
+                            validator: (value) {
+                              final text = value;
+                              if (text == null ||
+                                  text.isEmpty ||
+                                  text.length < 10) {
+                                return '10~11자 이내의 숫자';
+                              }
+
+                              if (text.isNotEmpty &&
+                                  !TextUtils.isPhoneNumberValid(text)) {
+                                return '10~11자 이내로 제대로된 전화번호를 입력해 주세요.';
+                              }
+
+                              return null;
+                            },
+                            maxLength: 11,
+                            inputFormatters: [
+                              // 숫자만 자판만 허용(한글, 영어, 이모티콘 다 안됨)
+                              FilteringTextInputFormatter.allow(
+                                RegExp(r'[0-9]'),
+                              ),
+                            ],
+                            keyboardType: TextInputType.number,
+                            decoration: InputDecoration(
+                              suffixIcon: InkWell(
+                                onTap: () => _phoneController.clear(),
+                                child: Icon(
+                                  Icons.cancel,
+                                  color: ColorsConstants.boldColor,
+                                  size: 20,
+                                ),
+                              ),
+                              helperText: "10~11자 이내의 숫자",
+                              helperStyle: TextStyle(
+                                color: ColorsConstants.strokeColor,
+                              ),
+                              prefixIcon: Icon(Icons.phone_enabled),
+                              prefixIconColor: ColorsConstants.strokeColor,
+                              iconColor: ColorsConstants.strokeColor,
+                              hintText: '예약자 휴대폰 번호를 입력해주세요.',
+                              hintStyle: TextStyle(
+                                color: ColorsConstants.textHint,
+                                fontSize: 15,
+                              ),
+                              labelText: '예약자 휴대폰 번호',
+                              labelStyle: TextStyle(
+                                color: ColorsConstants.strokeColor,
+                                fontSize: 14,
+                              ),
+                              focusedErrorBorder: OutlineInputBorder(
+                                borderRadius:
+                                BorderRadius.all(Radius.circular(10)),
+                                borderSide: BorderSide(
+                                  color: ColorsConstants.primary,
+                                  width: 1,
+                                ),
+                              ),
+                              errorBorder: OutlineInputBorder(
+                                borderRadius:
+                                BorderRadius.all(Radius.circular(10)),
+                                borderSide: BorderSide(
+                                  color: ColorsConstants.primary,
+                                  width: 1,
+                                ),
+                              ),
+                              enabledBorder: OutlineInputBorder(
+                                borderRadius:
+                                BorderRadius.all(Radius.circular(10)),
+                                borderSide: BorderSide(
+                                  color: ColorsConstants
+                                      .primaryButtonBackgroundDisabled,
+                                  width: 1,
+                                ),
+                              ),
+                              focusedBorder: OutlineInputBorder(
+                                borderRadius:
+                                BorderRadius.all(Radius.circular(10)),
+                                borderSide: BorderSide(
+                                  color: ColorsConstants.strokeColor,
+                                  width: 1,
+                                ),
+                              ),
+                              contentPadding:
+                              EdgeInsets.symmetric(vertical: 10),
+                            ),
+                            style: TextStyle(
+                              color: ColorsConstants.boldColor,
+                              fontSize: 15,
+                            ),
+                          ),
+                        ),
+                        Expanded(
+                          flex: 1,
+                          child: SizedBox(
+                            width: 10,
+                          ),
+                        ),
+                        Expanded(
+                          flex: 3,
+                          child: OutlinedButton(
+                            onPressed: () {
+                              if (!_nameKey.currentState!.validate() ||
+                                  !_phoneNumberKey.currentState!.validate()) {
+                                if (!_nameKey.currentState!.validate()) {
+                                  _onFocusOutInput(1);
+                                  _onFocusInput(context, 0);
+                                  return;
+                                }
+
+                                if (!_phoneNumberKey.currentState!.validate()) {
+                                  _onFocusOutInput(0);
+                                  _onFocusInput(context, 1);
+                                  return;
+                                }
+                              }
+
+                              _stopTimer();
+
+                              reservationFourthBloc.add(
+                                ReservationFourthRequestPhoneAuthNumber(
+                                  name: _nameController.text,
+                                  phoneNumber: _phoneController.text,
+                                ),
+                              );
+                            },
+                            style: ButtonStyle(
+                              side: MaterialStateProperty.all(
+                                BorderSide(
+                                  color:
+                                  _isNameValidate && _isPhoneNumberValidate
+                                      ? ColorsConstants.strokeColor
+                                      : ColorsConstants.primary,
+                                ),
+                              ), // 테두리 선 색상
+                              foregroundColor: MaterialStateProperty.all(
+                                _isNameValidate && _isPhoneNumberValidate
+                                    ? ColorsConstants.strokeColor
+                                    : ColorsConstants.primary,
+                              ), // 텍스트 색상
+                            ),
+                            child: Text(
+                              '인증번호\n전송',
+                              style: TextStyle(
+                                fontSize: 12,
+                                fontWeight: FontWeight.bold,
+                              ),
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
+                        ),
+                      ],
                     ),
-                  ),
-                  contentPadding: EdgeInsets.symmetric(vertical: 10),
-                ),
-                style: TextStyle(
-                  color: ColorsConstants.boldColor,
-                  fontSize: 15,
+                    Container(
+                      constraints: const BoxConstraints.expand(height: 30.0),
+                    ),
+                    BlocBuilder<ReservationFourthBloc, ReservationFourthState>(
+                      bloc: reservationFourthBloc,
+                      builder: (context, state) {
+                        return Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Expanded(
+                              flex: 7,
+                              child: TextFormField(
+                                key: _authPhoneNumberKey,
+                                controller: _authNumberController,
+                                focusNode: _focusNodes[2],
+                                autovalidateMode: AutovalidateMode.always,
+                                onChanged: (value) {
+                                  setState(() {
+                                    _isAuthCodeValidate =
+                                        value.isNotEmpty && value.length > 5;
+                                  });
+                                },
+                                validator: (value) {
+                                  if (_durationInSeconds == 0) {
+                                    return '인증번호를 재발급 받으세요..!';
+                                  }
+
+                                  final text = value;
+                                  if (text == null ||
+                                      text.isEmpty ||
+                                      text.length < 6) {
+                                    return '6자리 숫자 인증번호 입력';
+                                  }
+
+                                  return null;
+                                },
+                                maxLength: 6,
+                                inputFormatters: [
+                                  // 숫자만 자판만 허용(한글, 영어, 이모티콘 다 안됨)
+                                  FilteringTextInputFormatter.allow(
+                                      RegExp(r'[0-9]')),
+                                ],
+                                keyboardType: TextInputType.number,
+                                decoration: InputDecoration(
+                                  suffixIcon: InkWell(
+                                    onTap: () => _authNumberController.clear(),
+                                    child: Icon(
+                                      Icons.cancel,
+                                      color: ColorsConstants.boldColor,
+                                      size: 20,
+                                    ),
+                                  ),
+                                  helperText: "인증 버튼을 눌러주세요!",
+                                  helperStyle: TextStyle(
+                                    color: ColorsConstants.strokeColor,
+                                  ),
+                                  prefix: _timer != null
+                                      ? Padding(
+                                    padding: const EdgeInsets.only(right: 10),
+                                    child: Text(
+                                      DateTimeUtils.formatDuration(
+                                        _durationInSeconds,
+                                      ),
+                                      style: TextStyle(
+                                        color: ColorsConstants.strokeColor,
+                                        fontSize: 14,
+                                      ),
+                                    ),
+                                  )
+                                      : null,
+                                  iconColor: ColorsConstants.strokeColor,
+                                  label: Text(
+                                    '인증번호',
+                                    style: TextStyle(
+                                      color: ColorsConstants.strokeColor,
+                                      fontSize: 14,
+                                    ),
+                                    textAlign: TextAlign.center,
+                                  ),
+                                  focusedErrorBorder: OutlineInputBorder(
+                                    borderRadius:
+                                    BorderRadius.all(Radius.circular(10)),
+                                    borderSide: BorderSide(
+                                      color: ColorsConstants.primary,
+                                      width: 1,
+                                    ),
+                                  ),
+                                  errorBorder: OutlineInputBorder(
+                                    borderRadius:
+                                    BorderRadius.all(Radius.circular(10)),
+                                    borderSide: BorderSide(
+                                      color: ColorsConstants.primary,
+                                      width: 1,
+                                    ),
+                                  ),
+                                  enabledBorder: OutlineInputBorder(
+                                    borderRadius:
+                                    BorderRadius.all(Radius.circular(10)),
+                                    borderSide: BorderSide(
+                                      color: ColorsConstants
+                                          .primaryButtonBackgroundDisabled,
+                                      width: 1,
+                                    ),
+                                  ),
+                                  focusedBorder: OutlineInputBorder(
+                                    borderRadius:
+                                    BorderRadius.all(Radius.circular(10)),
+                                    borderSide: BorderSide(
+                                      color: ColorsConstants.strokeColor,
+                                      width: 1,
+                                    ),
+                                  ),
+                                  contentPadding: EdgeInsets.all(10),
+                                ),
+                                style: TextStyle(
+                                  color: ColorsConstants.boldColor,
+                                  fontSize: 15,
+                                ),
+                              ),
+                            ),
+                            Expanded(
+                              flex: 1,
+                              child: SizedBox(
+                                width: 10,
+                              ),
+                            ),
+                            Expanded(
+                              flex: 3,
+                              child: OutlinedButton(
+                                onPressed: () {
+                                  if (!state.isRequestSuccess) {
+                                    SnackBarUtils.showCustomSnackBar(
+                                      context,
+                                      "인증 번호를 발급받아 주세요.",
+                                    );
+                                  }
+
+                                  if (!_authPhoneNumberKey.currentState!
+                                      .validate()) {
+                                    _onFocusInput(context, 2);
+                                    return;
+                                  }
+
+                                  reservationFourthBloc.add(
+                                    ReservationFourthRequestPhoneAuthCheck(
+                                      authCode: _authNumberController.text,
+                                    ),
+                                  );
+                                },
+                                style: ButtonStyle(
+                                  side: MaterialStateProperty.all(
+                                    BorderSide(
+                                      color: _durationInSeconds != 0 &&
+                                          _isAuthCodeValidate
+                                          ? ColorsConstants.strokeColor
+                                          : ColorsConstants.primary,
+                                    ),
+                                  ), // 테두리 선 색상
+                                  foregroundColor: MaterialStateProperty
+                                      .all(
+                                    _durationInSeconds != 0 &&
+                                        _isAuthCodeValidate
+                                        ? ColorsConstants.strokeColor
+                                        : ColorsConstants.primary,
+                                  ), // 텍스트 색상
+                                ),
+                                child: Text(
+                                  '인증',
+                                  style: TextStyle(
+                                    fontSize: 12,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        );
+                      },
+                    ),
+                    BlocBuilder<ReservationFourthBloc, ReservationFourthState>(
+                      bloc: reservationFourthBloc,
+                      builder: (context, state) {
+                        if (state.isRequestSuccess && state.isCheckSuccess) {
+                          return Column(
+                            children: [
+                              Container(
+                                constraints: const BoxConstraints.expand(
+                                  height: 40,
+                                ),
+                              ),
+                              AnimatedTextKit(
+                                repeatForever: true,
+                                isRepeatingAnimation: true,
+                                animatedTexts: [
+                                  WavyAnimatedText(
+                                    "본인 인증에 성공하였습니다.",
+                                    textStyle: const TextStyle(
+                                      fontSize: 18,
+                                      fontWeight: FontWeight.w600,
+                                      color: ColorsConstants.strokeColor,
+                                    ),
+                                    speed: const Duration(milliseconds: 200),
+                                  ),
+                                  WavyAnimatedText(
+                                    "아래의 버튼을 클릭하면 예약이 완료됩니다!",
+                                    textStyle: const TextStyle(
+                                      fontSize: 18,
+                                      fontWeight: FontWeight.w600,
+                                      color: ColorsConstants.strokeColor,
+                                    ),
+                                    speed: const Duration(milliseconds: 200),
+                                  ),
+                                ],
+                                onTap: () {
+                                  debugPrint("Tap Event");
+                                },
+                              ),
+                            ],
+                          );
+                        } else {
+                          return SizedBox();
+                        }
+                      },
+                    ),
+                  ],
                 ),
               ),
-              Container(constraints: const BoxConstraints.expand(height: 25.0)),
-              TextFormField(
-                key: const Key('phoneNumberTextField'),
-                controller: phoneController,
-                maxLength: 11,
-                inputFormatters: [
-                  // 숫자만 자판만 허용(한글, 영어, 이모티콘 다 안됨)
-                  FilteringTextInputFormatter.allow(RegExp(r'[0-9]')),
-                ],
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(
-                  helperText: "10~11자 이내의 숫자",
-                  helperStyle: TextStyle(
-                    color: ColorsConstants.guideText,
-                  ),
-                  prefixIcon: Icon(Icons.phone_enabled),
-                  prefixIconColor: ColorsConstants.strokeColor,
-                  iconColor: ColorsConstants.strokeColor,
-                  hintText: '예약자 휴대폰 번호를 입력해주세요.',
-                  hintStyle: TextStyle(
-                    color: ColorsConstants.textHint,
-                    fontSize: 15,
-                  ),
-                  labelText: '예약자 휴대폰 번호',
-                  labelStyle: TextStyle(
-                    color: ColorsConstants.strokeColor,
-                    fontSize: 14,
-                  ),
-                  enabledBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.all(Radius.circular(10)),
-                    borderSide: BorderSide(
-                      color: ColorsConstants.primaryButtonBackgroundDisabled,
-                      width: 1,
-                    ),
-                  ),
-                  focusedBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.all(Radius.circular(10)),
-                    borderSide: BorderSide(
-                      color: ColorsConstants.strokeColor,
-                      width: 1,
-                    ),
-                  ),
-                  contentPadding: EdgeInsets.symmetric(vertical: 10),
-                ),
-                style: TextStyle(
-                  color: ColorsConstants.boldColor,
-                  fontSize: 15,
-                ),
-              ),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/presentation/views/reservation/widget/close_floating_action_widget.dart
+++ b/lib/presentation/views/reservation/widget/close_floating_action_widget.dart
@@ -111,6 +111,13 @@ class _CloseFloatingActionWidgetState extends State<CloseFloatingActionWidget>
 
           case 3:
             {
+              if (_animateIcon.value == 0 && state.isCheckedAuth) {
+                animate();
+              } else if (isOpened && !state.isCheckedAuth) {
+                _animationController.reverse();
+                isOpened = !isOpened;
+              }
+
               break;
             }
 
@@ -201,7 +208,17 @@ class _CloseFloatingActionWidgetState extends State<CloseFloatingActionWidget>
 
               case 3:
                 {
-                  return;
+                  if (_animateIcon.value == 0 && !state.isCheckedAuth) {
+                    DialogUtils.showBasicDialog(
+                      context: context,
+                      title: "알림",
+                      message: "본인 인증을 완료해주세요!",
+                    );
+
+                    return;
+                  }
+
+                  break;
                 }
 
               case 4:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -381,6 +381,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed:
+    dependency: "direct main"
+    description:
+      name: freezed
+      sha256: "2df89855fe181baae3b6d714dc3c4317acf4fccd495a6f36e5e00f24144c6c3b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  freezed_annotation:
+    dependency: "direct main"
+    description:
+      name: freezed_annotation
+      sha256: c3fd9336eb55a38cc1bbd79ab17573113a8deccd0ecbbf926cca3c62803b5c2d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   frontend_server_client:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,6 +79,9 @@ dependencies:
   # Font
   google_fonts: ^5.1.0
 
+  freezed: ^2.4.1
+  freezed_annotation: ^2.4.1
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## 🌸 예약 기능
- 이 브런치는 네 번째 Process 인 **_본인인증_** 작업에 관한 브런치임
  > **_📌 참고_**
  > -
  > #### 📍 예약 Process
  > - 1️⃣ 예약정보 입력
  > - 2️⃣ 좌석 선택
  > - 3️⃣ 약관동의
  > - 4️⃣ **_본인인증_**
  > - 5️⃣ 예약완료

### 🌹 Domain Layer
- SignRepository 생성
  > - `/sign/**` 관련 Repository 를 담당
  > - 사용자의 핸드폰에 인증번호를 전송하는 API 함수 생성
  > - 핸드폰 인증번호가 맞는지 체크하는 API 함수 생성
- UseCase
  > - GetAuthPhoneNumberUseCase 👉 인증번호를 발송하는 UseCase 생성
  > - GetAuthPhoneNumberCheckUseCase 👉 인증번호를 체크하는 UseCase 생성

### 🌹 Data Layer
- SignService 생성
  > - POST `/sign/phone` 👉 사용자의 핸드폰에 인증번호를 전송하는 API
  > - POST `/sign/phone/check` 👉 핸드폰 인증번호가 맞는지 체크하는 API
- SignRepositoryImpl 생성 및 구현
  > - 사용자의 핸드폰에 인증번호를 전송하는 API 함수 구현
  > - 핸드폰 인증번호가 맞는지 체크하는 API 함수 구현
- Model
  > - PhoneAuthRequest 👉 POST `/sign/phone` 의 Body 에 사용할 Model 생성
  > - PhoneAuthCheckRequest 👉 POST POST `/sign/phone/check` 의 Body 에 사용할 Model 생성 

### 🌹 Presentation Layer
- 본인 인증 페이지 구현 완료
- 본인 인증 로직
  - 1. 이름, 전화번호를 입력하면 **_인증번호_** 전송 버튼이 `enable` 됨
  - 2. 입력받은 이름, 전화번호를 바탕으로 **_인증 번호 전송 API_** 호출
  - 3. 인증 번호 API가 성공적으로 동작했다면 3분 Timer 가 시작됨
    > - 3분 이내에 인증번호를 입력하여 검증 받아야 함
  - 4. 발급 받은 인증 번호를 인증 번호 입력 창에 입력 후 **_인증_** 버튼 클릭
    > - 인증 번호를 받고 다시 인증번호를 재 발급 받는 다면 이전 인증번호로는 **_인증_** 이 이루어 지지 않음
  - 5. 인증에 성공하였다면 다음 화면으로 넘어갈 수 있게 `FloatingActionButton` 이 `enable` 됨
- ReservationFourthBloc
  - GetAuthPhoneNumberUseCase, GetAuthPhoneNumberCheckUseCase 를 주입받아 인증번호를 발송하고, 인증번호를 체크하는 기능 구현
  - `freezed` 를 사용하여 새로운 방식으로 Bloc State 관리

### 🌹 Dependency Injection
- SignService > SignRepository > Sign 관련 UseCase > ReservationFourthBloc 으로 가는 단방향 Dependency Injection Graph 생성