### PR TITLE
공지사항 탭 추가 

### DIFF
--- a/lib/presentation/config/router/app_router.dart
+++ b/lib/presentation/config/router/app_router.dart
@@ -1,4 +1,6 @@
 import 'package:auto_route/auto_route.dart';
+import 'package:reservation_app/domain/model/notice/notice_model.dart';
+import 'package:reservation_app/presentation/views/notice/notice_detail_screen.dart';
 
 import '../../views/main/main_screen.dart';
 import '../../views/notice/notice_screen.dart';
@@ -25,6 +27,12 @@ class AppRouter extends _$AppRouter {
         ),
         AutoRoute(
           page: NoticeRoute.page,
+          guards: [
+            DuplicateGuard(),
+          ],
+        ),
+        AutoRoute(
+          page: NoticeDetailRoute.page,
           guards: [
             DuplicateGuard(),
           ],

--- a/lib/presentation/config/router/app_router.gr.dart
+++ b/lib/presentation/config/router/app_router.gr.dart
@@ -27,6 +27,13 @@ abstract class _$AppRouter extends RootStackRouter {
         child: const ReservationScreen(),
       );
     },
+    NoticeDetailRoute.name: (routeData) {
+      final args = routeData.argsAs<NoticeDetailRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: NoticeDetailScreen(notice: args.notice),
+      );
+    },
     NoticeRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
@@ -68,6 +75,35 @@ class ReservationRoute extends PageRouteInfo<void> {
   static const String name = 'ReservationRoute';
 
   static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [NoticeDetailScreen]
+class NoticeDetailRoute extends PageRouteInfo<NoticeDetailRouteArgs> {
+  NoticeDetailRoute({
+    required NoticeModel notice,
+    List<PageRouteInfo>? children,
+  }) : super(
+          NoticeDetailRoute.name,
+          args: NoticeDetailRouteArgs(notice: notice),
+          initialChildren: children,
+        );
+
+  static const String name = 'NoticeDetailRoute';
+
+  static const PageInfo<NoticeDetailRouteArgs> page =
+      PageInfo<NoticeDetailRouteArgs>(name);
+}
+
+class NoticeDetailRouteArgs {
+  const NoticeDetailRouteArgs({required this.notice});
+
+  final NoticeModel notice;
+
+  @override
+  String toString() {
+    return 'NoticeDetailRouteArgs{notice: $notice}';
+  }
 }
 
 /// generated route for

--- a/lib/presentation/utils/constants.dart
+++ b/lib/presentation/utils/constants.dart
@@ -1,4 +1,3 @@
-
 class Constants {
   static final List<String> reservationProcessList = [
     '예약정보 입력',
@@ -16,4 +15,7 @@ class Constants {
     '[필수] 예약금을 내시면 환불이 어려워요!',
     '[필수] 좌석 변경이 불가능해요!'
   ];
+
+  static const noticeContentSample =
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
 }

--- a/lib/presentation/views/main/tabs/home/home_tab_screen.dart
+++ b/lib/presentation/views/main/tabs/home/home_tab_screen.dart
@@ -4,7 +4,11 @@ import 'package:expandable_bottom_sheet/expandable_bottom_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
+import 'package:reservation_app/domain/model/notice/notice_model.dart';
 import 'package:reservation_app/presentation/config/router/app_router.dart';
+import 'package:reservation_app/presentation/views/common/network_error_widget.dart';
+import 'package:reservation_app/presentation/views/common/network_loading_widget.dart';
+import 'package:reservation_app/presentation/views/main/tabs/home/tabs/notice/bloc/content_notice_tab_bloc.dart';
 
 import '../../../../utils/color_constants.dart';
 import '../../block/main_bloc.dart';
@@ -22,28 +26,56 @@ class _HomeTabScreenState extends State<HomeTabScreen> {
   @override
   Widget build(BuildContext context) {
     final mainBlock = BlocProvider.of<MainBloc>(context);
+    final contentNoticeTabBloc = BlocProvider.of<ContentNoticeTabBloc>(context)
+      ..add(
+        ContentNoticeTabNoticeListEvent(),
+      );
 
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.white,
         title: Center(
-          child: AnimatedTextKit(
-            repeatForever: true,
-            isRepeatingAnimation: true,
-            animatedTexts: [
-              WavyAnimatedText(
-                "공지사항 들어갈거임",
-                textStyle: const TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                  color: ColorsConstants.splashText,
-                ),
-              ),
-            ],
-            onTap: () {
-              debugPrint("Tap Event");
-            },
-          ),
+          child: BlocBuilder<ContentNoticeTabBloc, ContentNoticeTabState>(
+              bloc: contentNoticeTabBloc,
+              builder: (context, state) {
+                switch (state.runtimeType) {
+                  case ContentNoticeTabStateLoading:
+                    return const NetworkLoadingWidget();
+
+                  case ContentNoticeTabStateNoticeListFailed:
+                    final errorMessage =
+                        (state as ContentNoticeTabStateNoticeListFailed)
+                            .message;
+                    return NetworkErrorWidget(
+                      errorMessage: errorMessage,
+                    );
+
+                  case ContentNoticeTabStateNoticeList:
+                    final List<NoticeModel> noticeList =
+                        (state as ContentNoticeTabStateNoticeList).noticeList;
+
+                    // noticeList.map((e) => WavyAnimatedText(e.title.toString()));
+                    return DefaultTextStyle(
+                      style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600,
+                          color: ColorsConstants.splashText),
+                      child: AnimatedTextKit(
+                        animatedTexts: noticeList
+                            .map((e) => WavyAnimatedText(e.title.toString()))
+                            .toList(),
+                        isRepeatingAnimation: true,
+                        repeatForever: true,
+                        onTap: () {
+                          // debugPrint("$e");
+                        },
+                        pause: const Duration(milliseconds: 2000),
+                      ),
+                    );
+                  default:
+                    return Text("Test");
+                }
+              }),
         ),
         leading: Padding(
           padding: EdgeInsets.only(left: 10.0),

--- a/lib/presentation/views/main/tabs/home/tabs/notice/component/gallery_item_thumbnail.dart
+++ b/lib/presentation/views/main/tabs/home/tabs/notice/component/gallery_item_thumbnail.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:reservation_app/data/utils/Endpoints.dart';
+import 'package:reservation_app/domain/model/notice/image/notice_image_model.dart';
+
+class GalleryItemThumbnail extends StatelessWidget {
+  const GalleryItemThumbnail({
+    Key? key,
+    required this.galleryExampleItem,
+  }) : super(key: key);
+
+  final NoticeImageModel galleryExampleItem;
+
+  @override
+  Widget build(BuildContext context) {
+    // debugPrint("galleryExampleItem 👉$galleryExampleItem");
+    Size size = MediaQuery.of(context).size;
+
+    return Container(
+      padding: EdgeInsets.only(left: 20, right: 20, bottom: 10),
+      child: Hero(
+        tag: galleryExampleItem.id,
+        child: Image.network(
+            Endpoints.baseImageUrl + galleryExampleItem.imageUrl,
+            width: (size.width - 70),
+            fit: BoxFit.fitWidth),
+      ),
+    );
+  }
+}

--- a/lib/presentation/views/main/tabs/home/tabs/notice/content_notice_tab_screen.dart
+++ b/lib/presentation/views/main/tabs/home/tabs/notice/content_notice_tab_screen.dart
@@ -8,6 +8,7 @@ import 'package:reservation_app/domain/model/notice/image/notice_image_model.dar
 import 'package:reservation_app/domain/model/notice/notice_model.dart';
 import 'package:reservation_app/presentation/config/router/app_router.dart';
 import 'package:reservation_app/presentation/utils/color_constants.dart';
+import 'package:reservation_app/presentation/utils/constants.dart';
 import 'package:reservation_app/presentation/views/common/network_error_widget.dart';
 import 'package:reservation_app/presentation/views/common/network_loading_widget.dart';
 import 'package:reservation_app/presentation/views/main/tabs/home/tabs/notice/bloc/content_notice_tab_bloc.dart';
@@ -86,10 +87,6 @@ class _ContentNoticeTabScreenState extends State<ContentNoticeTabScreen> {
     );
   }
 }
-
-//공지사항 contents 샘플
-const loremIpsum =
-    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
 
 class CustomCard extends StatefulWidget {
   const CustomCard({Key? key, required this.notice}) : super(key: key);
@@ -254,7 +251,8 @@ class _CustomCardState extends State<CustomCard> {
           Padding(
               padding: EdgeInsets.all(10),
               child: Text(
-                loremIpsum,
+                // widget.notice.content
+                Constants.noticeContentSample,
                 softWrap: true,
                 overflow: TextOverflow.ellipsis,
                 maxLines: 3,

--- a/lib/presentation/views/main/tabs/home/tabs/notice/content_notice_tab_screen.dart
+++ b/lib/presentation/views/main/tabs/home/tabs/notice/content_notice_tab_screen.dart
@@ -1,6 +1,24 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:custom_pop_up_menu/custom_pop_up_menu.dart';
+import 'package:expandable/expandable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reservation_app/data/utils/Endpoints.dart';
+import 'package:reservation_app/domain/model/notice/image/notice_image_model.dart';
+import 'package:reservation_app/domain/model/notice/notice_model.dart';
+import 'package:reservation_app/presentation/config/router/app_router.dart';
+import 'package:reservation_app/presentation/utils/color_constants.dart';
+import 'package:reservation_app/presentation/views/common/network_error_widget.dart';
+import 'package:reservation_app/presentation/views/common/network_loading_widget.dart';
 import 'package:reservation_app/presentation/views/main/tabs/home/tabs/notice/bloc/content_notice_tab_bloc.dart';
+import 'package:reservation_app/presentation/views/main/tabs/home/tabs/notice/component/gallery_item_thumbnail.dart';
+
+class ItemModel {
+  String title;
+  IconData icon;
+
+  ItemModel(this.title, this.icon);
+}
 
 class ContentNoticeTabScreen extends StatefulWidget {
   const ContentNoticeTabScreen({Key? key}) : super(key: key);
@@ -12,11 +30,285 @@ class ContentNoticeTabScreen extends StatefulWidget {
 class _ContentNoticeTabScreenState extends State<ContentNoticeTabScreen> {
   @override
   Widget build(BuildContext context) {
-    final contentNoticeTabBloc =
-        BlocProvider.of<ContentNoticeTabBloc>(context).add(
-      ContentNoticeTabNoticeListEvent(),
-    );
+    final contentNoticeTabBloc = BlocProvider.of<ContentNoticeTabBloc>(context)
+      ..add(
+        ContentNoticeTabNoticeListEvent(),
+      );
 
-    return Center(child: Text("공지사항"));
+    return Container(
+      color: ColorsConstants.background,
+      child: BlocBuilder<ContentNoticeTabBloc, ContentNoticeTabState>(
+          bloc: contentNoticeTabBloc,
+          builder: (context, state) {
+            switch (state.runtimeType) {
+              case ContentNoticeTabStateLoading:
+                return const NetworkLoadingWidget();
+
+              case ContentNoticeTabStateNoticeListFailed:
+                final errorMessage =
+                    (state as ContentNoticeTabStateNoticeListFailed).message;
+                return NetworkErrorWidget(
+                  errorMessage: errorMessage,
+                );
+
+              case ContentNoticeTabStateNoticeList:
+                final List<NoticeModel> noticeList =
+                    (state as ContentNoticeTabStateNoticeList).noticeList;
+
+                return LayoutBuilder(
+                  builder: (context, constraints) {
+                    return Scaffold(
+                      body: ExpandableTheme(
+                        data: const ExpandableThemeData(
+                          iconColor: Colors.blue,
+                          useInkWell: true,
+                        ),
+                        child: ListView.builder(
+                          itemCount: noticeList.length,
+                          physics: const BouncingScrollPhysics(),
+                          itemBuilder: (context, index) {
+                            final notice = noticeList[index];
+                            notice.createdAt.replaceAll("T", " / ");
+                            return CustomCard(notice: notice);
+                          },
+                        ),
+                      ),
+                    );
+                  },
+                );
+
+              default:
+                return const NetworkErrorWidget(
+                  errorMessage: '네트워크가 원활하지 않습니다. \n 잠시 후 다시 시도해주세요.',
+                );
+            }
+          }),
+    );
+  }
+}
+
+//공지사항 contents 샘플
+const loremIpsum =
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+
+class CustomCard extends StatefulWidget {
+  const CustomCard({Key? key, required this.notice}) : super(key: key);
+  final NoticeModel notice;
+
+  @override
+  State<CustomCard> createState() => _CustomCardState();
+}
+
+class _CustomCardState extends State<CustomCard> {
+  CustomPopupMenuController popupController = CustomPopupMenuController();
+
+  List<ItemModel> menuItems = [
+    ItemModel("펼치기", Icons.open_in_browser_rounded),
+    ItemModel("상세보기", Icons.developer_board_rounded),
+    ItemModel("수정", Icons.auto_fix_high_rounded),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    buildPressMenu(
+        BuildContext context, CustomPopupMenuController popupController) {
+      var expandController = ExpandableController.of(context, required: true)!;
+
+      return ClipRRect(
+        borderRadius: BorderRadius.circular(5),
+        child: Container(
+          width: 110,
+          height: 120,
+          color: Colors.black,
+          child: ListView.builder(
+              padding: EdgeInsets.zero,
+              physics: NeverScrollableScrollPhysics(),
+              itemCount: menuItems.length,
+              itemBuilder: (BuildContext context, int index) {
+                return Container(
+                    width: 110,
+                    height: 40,
+                    padding: EdgeInsets.symmetric(horizontal: 10),
+                    child: InkWell(
+                      onTap: () {
+                        if (index == 0) {
+                          expandController.toggle();
+                        } else if (index == 1) {
+                          AutoRouter.of(context)
+                              .push(NoticeDetailRoute(notice: widget.notice));
+                        }
+                        popupController.hideMenu();
+                      },
+                      child: Row(
+                        children: <Widget>[
+                          Icon(
+                            menuItems[index].icon,
+                            size: 20,
+                            color: Colors.white,
+                          ),
+                          Container(
+                            margin: EdgeInsets.only(left: 10),
+                            child: Text(
+                              menuItems[index].title,
+                              style: TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.bold),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ));
+              }),
+        ),
+      );
+    }
+
+    buildCollapsedTop() {
+      return Padding(
+        padding: EdgeInsets.only(top: 10, left: 10, right: 10, bottom: 15),
+        child: Text(
+          widget.notice.title,
+          overflow: TextOverflow.ellipsis,
+          maxLines: 1,
+          style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+          softWrap: false,
+        ),
+      );
+    }
+
+    buildExpandedTop() {
+      return Center(
+        child: Padding(
+          padding: EdgeInsets.only(top: 10, left: 10, right: 10, bottom: 30),
+          child: Text(
+            widget.notice.title,
+            style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+          ),
+        ),
+      );
+    }
+
+    buildCollapsedMiddle() {
+      if (widget.notice.images.isEmpty) {
+        return SizedBox.shrink();
+      } else {
+        return Image.network(
+          Endpoints.baseImageUrl + widget.notice.images[0].imageUrl,
+          fit: BoxFit.cover,
+          width: double.infinity,
+        );
+      }
+    }
+
+    buildExpandedMiddle(List<NoticeImageModel> images) {
+      if (images.isNotEmpty) {
+        return Column(
+          children: images
+              .asMap()
+              .entries
+              .map((item) => Row(children: [
+                    GalleryItemThumbnail(
+                      galleryExampleItem: item.value,
+                    )
+                  ]))
+              .toList(),
+        );
+      } else {
+        return SizedBox.shrink();
+      }
+    }
+
+    buildCollapsedBottom() {
+      return Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: <Widget>[
+          Padding(
+              padding: EdgeInsets.only(left: 10),
+              child: Text(
+                widget.notice.createdAt,
+                softWrap: true,
+                overflow: TextOverflow.fade,
+              )),
+          Builder(builder: (context) {
+            return CustomPopupMenu(
+              menuBuilder: () => buildPressMenu(context, popupController),
+              pressType: PressType.singleClick,
+              verticalMargin: -15,
+              controller: popupController,
+              child: Container(
+                padding: EdgeInsets.only(top: 10, bottom: 10),
+                child: Icon(Icons.more_vert_sharp),
+              ),
+            );
+          }),
+        ],
+      );
+    }
+
+    buildExpandedBottom() {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Padding(
+              padding: EdgeInsets.all(10),
+              child: Text(
+                loremIpsum,
+                softWrap: true,
+                overflow: TextOverflow.ellipsis,
+                maxLines: 3,
+              )),
+          Builder(builder: (context) {
+            var controller = ExpandableController.of(context, required: true)!;
+
+            return Center(
+              child: IconButton(
+                onPressed: () {
+                  controller.toggle();
+                },
+                icon: Icon(Icons.arrow_drop_up),
+                iconSize: 30,
+              ),
+            );
+          }),
+        ],
+      );
+    }
+
+    return ExpandableNotifier(
+      child: Padding(
+        padding:
+            const EdgeInsets.only(top: 15, left: 10, right: 10, bottom: 15),
+        child: ScrollOnExpand(
+          child: Card(
+            clipBehavior: Clip.antiAlias,
+            shape: RoundedRectangleBorder(
+              side: BorderSide(color: Colors.black),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Expandable(
+                  collapsed: buildCollapsedTop(),
+                  expanded: buildExpandedTop(),
+                ),
+                Expandable(
+                  collapsed: buildCollapsedMiddle(),
+                  expanded: buildExpandedMiddle(widget.notice.images),
+                ),
+                Divider(
+                  height: 1,
+                ),
+                Expandable(
+                  collapsed: buildCollapsedBottom(),
+                  expanded: buildExpandedBottom(),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/presentation/views/notice/notice_detail_screen.dart
+++ b/lib/presentation/views/notice/notice_detail_screen.dart
@@ -7,6 +7,7 @@ import 'package:reservation_app/data/utils/Endpoints.dart';
 import 'package:reservation_app/domain/model/notice/image/notice_image_model.dart';
 import 'package:reservation_app/domain/model/notice/notice_model.dart';
 import 'package:reservation_app/presentation/utils/color_constants.dart';
+import 'package:reservation_app/presentation/utils/constants.dart';
 
 @RoutePage()
 class NoticeDetailScreen extends StatefulWidget {
@@ -142,10 +143,9 @@ class _NoticeDetailScreenState extends State<NoticeDetailScreen> {
     }
 
     buildContent() {
-      const loremIpsum =
-          "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
       return Text(
-        loremIpsum,
+        // widget.notice.content,
+        Constants.noticeContentSample,
         style: TextStyle(
           fontSize: 13,
           color: Colors.black,

--- a/lib/presentation/views/notice/notice_detail_screen.dart
+++ b/lib/presentation/views/notice/notice_detail_screen.dart
@@ -1,0 +1,320 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:carousel_slider/carousel_slider.dart';
+import 'package:flutter/material.dart';
+import 'package:photo_view/photo_view.dart';
+import 'package:photo_view/photo_view_gallery.dart';
+import 'package:reservation_app/data/utils/Endpoints.dart';
+import 'package:reservation_app/domain/model/notice/image/notice_image_model.dart';
+import 'package:reservation_app/domain/model/notice/notice_model.dart';
+import 'package:reservation_app/presentation/utils/color_constants.dart';
+
+@RoutePage()
+class NoticeDetailScreen extends StatefulWidget {
+  const NoticeDetailScreen({required this.notice});
+
+  final NoticeModel notice;
+  @override
+  State<NoticeDetailScreen> createState() => _NoticeDetailScreenState();
+}
+
+class _NoticeDetailScreenState extends State<NoticeDetailScreen> {
+  int currentIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    Size size = MediaQuery.of(context).size;
+
+    buildTitle() {
+      List<String> splitCreateDateTime = widget.notice.createdAt.split("T");
+      String parseCreateDate =
+          splitCreateDateTime[0].replaceAll("-", "/").substring(2);
+      String titleText = widget.notice.title;
+      debugPrint('parseCreateDate 👉 $parseCreateDate');
+      debugPrint(splitCreateDateTime[1]);
+
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            parseCreateDate,
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w300,
+              color: ColorsConstants.guideText,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 10),
+            child: Text(
+              titleText,
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.w500,
+                color: ColorsConstants.boldColor,
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
+    buildImageList() {
+      if (widget.notice.images.isEmpty) {
+        return Container();
+      } else {
+        List<String> images = widget.notice.images
+            .map((e) => (Endpoints.baseImageUrl + e.imageUrl))
+            .toList();
+
+        return CarouselSlider(
+            options: CarouselOptions(
+              autoPlay: false,
+              onPageChanged: (index, reason) {
+                setState(
+                  () {
+                    currentIndex = index;
+                  },
+                );
+              },
+              enableInfiniteScroll: false,
+            ),
+            items: images
+                .map(
+                  (item) => Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: Card(
+                      margin: EdgeInsets.only(
+                        top: 10.0,
+                        bottom: 10.0,
+                      ),
+                      elevation: 6.0,
+                      shadowColor: ColorsConstants.divider,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(30.0),
+                      ),
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.all(
+                          Radius.circular(30.0),
+                        ),
+                        child: GestureDetector(
+                          onTap: () {
+                            open(context, currentIndex);
+                          },
+                          child: Hero(
+                            tag: item,
+                            child: Image.network(
+                              item,
+                              fit: BoxFit.cover,
+                              width: double.infinity,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                )
+                .toList());
+
+        // return ListView.builder(
+        //   physics: BouncingScrollPhysics(),
+        //   itemCount: sampleImages.length,
+        //   scrollDirection: Axis.horizontal,
+        //   controller: _scrollController,
+        //   dragStartBehavior: DragStartBehavior.start,
+        //   itemBuilder: (BuildContext context, int index) {
+        //     return Container(
+        //       padding: EdgeInsets.only(left: 10, right: 10, bottom: 10),
+        //       child: GestureDetector(
+        //         onTap: () {
+        //           debugPrint('index 👉 $index');
+        //           open(context, index);
+        //         },
+        //         child: Hero(
+        //           tag: sampleImages[index],
+        //           child: Image.network(sampleImages[index],
+        //               width: (size.width - 20), fit: BoxFit.fitWidth),
+        //         ),
+        //       ),
+        //     );
+        //   },
+        // );
+      }
+    }
+
+    buildContent() {
+      const loremIpsum =
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+      return Text(
+        loremIpsum,
+        style: TextStyle(
+          fontSize: 13,
+          color: Colors.black,
+          fontWeight: FontWeight.w300,
+        ),
+      );
+    }
+
+    // debugPrint("notice => ${widget.notice}");
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        centerTitle: true,
+        title: Text(
+          '공지사항',
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+            color: ColorsConstants.splashText,
+          ),
+        ),
+        leading: AutoLeadingButton(color: ColorsConstants.splashText),
+        elevation: 3,
+      ),
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Container(
+              color: Colors.grey[100],
+              width: size.width,
+              padding: EdgeInsets.symmetric(
+                horizontal: 10,
+                vertical: 15,
+              ),
+              child: buildTitle(),
+            ),
+            Container(
+              color: Colors.grey[300],
+              width: size.width,
+              height: 300,
+              child: Padding(
+                padding: EdgeInsets.symmetric(vertical: 10),
+                child: buildImageList(),
+              ),
+            ),
+            Expanded(
+              child: SizedBox(
+                width: size.width,
+                child: Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+                  child: buildContent(),
+                ),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+  void open(BuildContext context, final int index) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => GalleryPhotoViewWrapper(
+          galleryItems: widget.notice.images,
+          backgroundDecoration: const BoxDecoration(
+            color: Colors.black,
+          ),
+          initialIndex: index,
+          scrollDirection: Axis.horizontal,
+        ),
+      ),
+    );
+  }
+}
+
+class GalleryPhotoViewWrapper extends StatefulWidget {
+  GalleryPhotoViewWrapper({
+    this.loadingBuilder,
+    this.backgroundDecoration,
+    this.minScale,
+    this.maxScale,
+    this.initialIndex = 0,
+    required this.galleryItems,
+    this.scrollDirection = Axis.horizontal,
+  }) : pageController = PageController(initialPage: initialIndex);
+
+  final LoadingBuilder? loadingBuilder;
+  final BoxDecoration? backgroundDecoration;
+  final dynamic minScale;
+  final dynamic maxScale;
+  final int initialIndex;
+  final PageController pageController;
+  final List<NoticeImageModel> galleryItems;
+  final Axis scrollDirection;
+
+  @override
+  State<StatefulWidget> createState() {
+    return _GalleryPhotoViewWrapperState();
+  }
+}
+
+class _GalleryPhotoViewWrapperState extends State<GalleryPhotoViewWrapper> {
+  late int currentIndex = widget.initialIndex;
+
+  void onPageChanged(int index) {
+    setState(() {
+      currentIndex = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        decoration: widget.backgroundDecoration,
+        constraints: BoxConstraints.expand(
+          height: MediaQuery.of(context).size.height,
+        ),
+        child: Stack(
+          alignment: Alignment.topRight,
+          children: <Widget>[
+            PhotoViewGallery.builder(
+              scrollPhysics: const BouncingScrollPhysics(),
+              builder: _buildItem,
+              itemCount: widget.galleryItems.length,
+              loadingBuilder: widget.loadingBuilder,
+              backgroundDecoration: widget.backgroundDecoration,
+              pageController: widget.pageController,
+              onPageChanged: onPageChanged,
+              scrollDirection: widget.scrollDirection,
+            ),
+            SafeArea(
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () {
+                  close();
+                },
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 20, right: 20),
+                  child: Icon(
+                    Icons.exit_to_app_rounded,
+                    size: 30,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  PhotoViewGalleryPageOptions _buildItem(BuildContext context, int index) {
+    final NoticeImageModel item = widget.galleryItems[index];
+    String imgUrl = Endpoints.baseImageUrl + item.imageUrl;
+    return PhotoViewGalleryPageOptions(
+      imageProvider: NetworkImage(imgUrl),
+      initialScale: PhotoViewComputedScale.contained,
+      minScale: PhotoViewComputedScale.contained * (0.5 + index / 10),
+      maxScale: PhotoViewComputedScale.covered * 4.1,
+      heroAttributes: PhotoViewHeroAttributes(tag: item.id),
+    );
+  }
+
+  void close() {
+    AutoRouter.of(context).pop();
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -233,6 +233,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  custom_pop_up_menu:
+    dependency: "direct main"
+    description:
+      name: custom_pop_up_menu
+      sha256: eeac484c6ddffffb25e803dc2a5cc9381e700a29f074e9fcc76fe36b62fde850
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.4"
   dart_style:
     dependency: transitive
     description:
@@ -257,6 +265,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
+  expandable:
+    dependency: "direct main"
+    description:
+      name: expandable
+      sha256: "9604d612d4d1146dafa96c6d8eec9c2ff0994658d6d09fed720ab788c7f5afc2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.1"
   expandable_bottom_sheet:
     dependency: "direct main"
     description:
@@ -661,6 +677,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.0"
+  photo_view:
+    dependency: "direct main"
+    description:
+      name: photo_view
+      sha256: "8036802a00bae2a78fc197af8a158e3e2f7b500561ed23b4c458107685e645bb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.14.0"
   platform:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,6 +70,10 @@ dependencies:
     sdk: flutter
   flutter_rounded_date_picker: ^3.0.4
 
+  expandable: ^5.0.1
+  photo_view: ^0.14.0
+  custom_pop_up_menu: ^1.2.4
+
   # Web View 띄우기
   url_launcher: ^6.1.11
 


### PR DESCRIPTION
## 🍏 공지사항
- NoticeDetailScreen 추가
- 공지사항
  > 1️⃣ 펼치기 기능
  > 2️⃣ 상세정보 보기
  > 3️⃣ 수정하기(추가할 예정)

### 🍎 Dependency
- expandable 👉 공지사항 탭에서 공지사항 목록들을 미리 간략하게 볼수 있도록 확장가능하게 추가
- photo_view 👉 공지사항에 올라온 이미지 클릭시 확대해서 볼 수 있도록 하기위해 추가
- custom_pop_up_menu 👉 공지사항 더보기(펼치기, 상세정보, 수정) 메뉴를 팝업으로 띄우기위해 추가
> ``` yaml
> dependencies:
>  expandable: ^5.0.1
>  photo_view: ^0.14.0
>  custom_pop_up_menu: ^1.2.4
> ```