### PR TITLE
🦋 Table_Calendar 라이브러리를 활용한 예약 달력 기능 구현 🦋

### DIFF
--- a/lib/data/api/reservation/reservation_api_service.dart
+++ b/lib/data/api/reservation/reservation_api_service.dart
@@ -6,6 +6,7 @@ import 'package:reservation_app/data/model/reservation/reservation_approval_chec
 import 'package:reservation_app/data/model/reservation/reservation_create_request.dart';
 import 'package:reservation_app/data/model/reservation/reservation_detail_response.dart';
 import 'package:reservation_app/data/model/reservation/reservation_non_auth_response.dart';
+import 'package:reservation_app/data/model/reservation/reservation_range_section_response.dart';
 import 'package:reservation_app/data/model/reservation/reservation_target_date_response.dart';
 import 'package:reservation_app/domain/model/reservation/enum/part_time.dart';
 import 'package:reservation_app/domain/model/reservation/enum/reservation_filter_type.dart';
@@ -65,5 +66,12 @@ abstract class ReservationApiService {
   Future<BaseResponse<ReservationDetailResponse>>
       requestReservationDetailByUser(
     @Query("certificationNumber") String certificationNumber,
+  );
+
+  @GET("/reservation/range")
+  Future<BaseListResponse<ReservationRangeSectionResponse>>
+      requestReservationRangeList(
+    @Query("searchStartDate") String startDate,
+    @Query("searchEndDate") String endDate,
   );
 }

--- a/lib/data/api/reservation/reservation_api_service.g.dart
+++ b/lib/data/api/reservation/reservation_api_service.g.dart
@@ -257,6 +257,41 @@ class _ReservationApiService implements ReservationApiService {
     return value;
   }
 
+  @override
+  Future<BaseListResponse<ReservationRangeSectionResponse>>
+      requestReservationRangeList(
+    startDate,
+    endDate,
+  ) async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{
+      r'searchStartDate': startDate,
+      r'searchEndDate': endDate,
+    };
+    final _headers = <String, dynamic>{};
+    final Map<String, dynamic>? _data = null;
+    final _result = await _dio.fetch<Map<String, dynamic>>(
+        _setStreamType<BaseListResponse<ReservationRangeSectionResponse>>(
+            Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+                .compose(
+                  _dio.options,
+                  '/reservation/range',
+                  queryParameters: queryParameters,
+                  data: _data,
+                )
+                .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    final value = BaseListResponse<ReservationRangeSectionResponse>.fromJson(
+      _result.data!,
+      (json) => ReservationRangeSectionResponse.fromJson(
+          json as Map<String, dynamic>),
+    );
+    return value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/data/api/sign/sign_api_service.dart
+++ b/lib/data/api/sign/sign_api_service.dart
@@ -4,6 +4,7 @@ import 'package:reservation_app/data/model/sign/phone_auth_check_request.dart';
 import 'package:reservation_app/data/model/sign/phone_auth_request.dart';
 import 'package:reservation_app/data/model/sign/sign_in_request.dart';
 import 'package:reservation_app/data/model/sign/sign_in_response.dart';
+import 'package:reservation_app/data/model/sign/sign_out_request.dart';
 import 'package:retrofit/http.dart';
 
 part 'sign_api_service.g.dart';
@@ -18,7 +19,9 @@ abstract class SignApiService {
   );
 
   @POST("/sign/signOut")
-  Future<BaseResponse> requestSignOut();
+  Future<BaseResponse> requestSignOut(
+    @Body() SignOutRequest request,
+  );
 
   @POST("/sign/phone")
   Future<BaseResponse> requestAuthPhoneNumber(

--- a/lib/data/api/sign/sign_api_service.g.dart
+++ b/lib/data/api/sign/sign_api_service.g.dart
@@ -46,11 +46,12 @@ class _SignApiService implements SignApiService {
   }
 
   @override
-  Future<BaseResponse<dynamic>> requestSignOut() async {
+  Future<BaseResponse<dynamic>> requestSignOut(request) async {
     const _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
-    final Map<String, dynamic>? _data = null;
+    final _data = <String, dynamic>{};
+    _data.addAll(request.toJson());
     final _result = await _dio.fetch<Map<String, dynamic>>(
         _setStreamType<BaseResponse<dynamic>>(Options(
       method: 'POST',

--- a/lib/data/datasource/impl/remote_data_source_impl.dart
+++ b/lib/data/datasource/impl/remote_data_source_impl.dart
@@ -13,6 +13,7 @@ import 'package:reservation_app/data/model/reservation/reservation_approval_chec
 import 'package:reservation_app/data/model/reservation/reservation_create_request.dart';
 import 'package:reservation_app/data/model/reservation/reservation_detail_response.dart';
 import 'package:reservation_app/data/model/reservation/reservation_non_auth_response.dart';
+import 'package:reservation_app/data/model/reservation/reservation_range_section_response.dart';
 import 'package:reservation_app/data/model/reservation/reservation_target_date_response.dart';
 import 'package:reservation_app/data/model/sign/phone_auth_check_request.dart';
 import 'package:reservation_app/data/model/sign/phone_auth_request.dart';
@@ -130,6 +131,18 @@ class RemoteDataSourceImpl implements RemoteDataSource {
   ) {
     return _reservationApiService.requestReservationDetailByUser(
       certificationNumber,
+    );
+  }
+
+  @override
+  Future<BaseListResponse<ReservationRangeSectionResponse>>
+      requestReservationRangeList(
+    String startDate,
+    String endDate,
+  ) {
+    return _reservationApiService.requestReservationRangeList(
+      startDate,
+      endDate,
     );
   }
 

--- a/lib/data/datasource/impl/remote_data_source_impl.dart
+++ b/lib/data/datasource/impl/remote_data_source_impl.dart
@@ -18,6 +18,7 @@ import 'package:reservation_app/data/model/sign/phone_auth_check_request.dart';
 import 'package:reservation_app/data/model/sign/phone_auth_request.dart';
 import 'package:reservation_app/data/model/sign/sign_in_request.dart';
 import 'package:reservation_app/data/model/sign/sign_in_response.dart';
+import 'package:reservation_app/data/model/sign/sign_out_request.dart';
 import 'package:reservation_app/domain/model/banner/banner_image_model.dart';
 import 'package:reservation_app/domain/model/notice/notice_model.dart';
 import 'package:reservation_app/domain/model/reservation/enum/part_time.dart';
@@ -140,8 +141,8 @@ class RemoteDataSourceImpl implements RemoteDataSource {
   }
 
   @override
-  Future<BaseResponse> requestSignOut() {
-    return _signApiService.requestSignOut();
+  Future<BaseResponse> requestSignOut(SignOutRequest request) {
+    return _signApiService.requestSignOut(request);
   }
 
   @override

--- a/lib/data/datasource/remote_data_source.dart
+++ b/lib/data/datasource/remote_data_source.dart
@@ -12,6 +12,7 @@ import 'package:reservation_app/data/model/sign/phone_auth_check_request.dart';
 import 'package:reservation_app/data/model/sign/phone_auth_request.dart';
 import 'package:reservation_app/data/model/sign/sign_in_request.dart';
 import 'package:reservation_app/data/model/sign/sign_in_response.dart';
+import 'package:reservation_app/data/model/sign/sign_out_request.dart';
 import 'package:reservation_app/domain/model/banner/banner_image_model.dart';
 import 'package:reservation_app/domain/model/notice/notice_model.dart';
 import 'package:reservation_app/domain/model/reservation/enum/part_time.dart';
@@ -76,7 +77,7 @@ abstract class RemoteDataSource {
     SignInRequest request,
   );
 
-  Future<BaseResponse> requestSignOut();
+  Future<BaseResponse> requestSignOut(SignOutRequest request);
 
   Future<BaseResponse> requestAuthPhoneNumber(
     PhoneAuthRequest request,

--- a/lib/data/datasource/remote_data_source.dart
+++ b/lib/data/datasource/remote_data_source.dart
@@ -7,6 +7,7 @@ import 'package:reservation_app/data/model/reservation/reservation_approval_chec
 import 'package:reservation_app/data/model/reservation/reservation_create_request.dart';
 import 'package:reservation_app/data/model/reservation/reservation_detail_response.dart';
 import 'package:reservation_app/data/model/reservation/reservation_non_auth_response.dart';
+import 'package:reservation_app/data/model/reservation/reservation_range_section_response.dart';
 import 'package:reservation_app/data/model/reservation/reservation_target_date_response.dart';
 import 'package:reservation_app/data/model/sign/phone_auth_check_request.dart';
 import 'package:reservation_app/data/model/sign/phone_auth_request.dart';
@@ -70,6 +71,12 @@ abstract class RemoteDataSource {
   Future<BaseResponse<ReservationDetailResponse>>
       requestReservationDetailByUser(
     String certificationNumber,
+  );
+
+  Future<BaseListResponse<ReservationRangeSectionResponse>>
+      requestReservationRangeList(
+    String startDate,
+    String endDate,
   );
 
   // Sign

--- a/lib/data/mapper/object_mapper.dart
+++ b/lib/data/mapper/object_mapper.dart
@@ -5,12 +5,14 @@ import 'package:reservation_app/data/model/reservation/reservation_approval_chec
 import 'package:reservation_app/data/model/reservation/reservation_detail_response.dart';
 import 'package:reservation_app/data/model/reservation/reservation_non_auth_response.dart';
 import 'package:reservation_app/data/model/sign/sign_in_request.dart';
+import 'package:reservation_app/data/model/sign/sign_out_request.dart';
 import 'package:reservation_app/domain/model/member/member_model.dart';
 import 'package:reservation_app/domain/model/reservation/page/reservation_filter_list_model.dart';
 import 'package:reservation_app/domain/model/reservation/page/reservation_filter_model.dart';
 import 'package:reservation_app/domain/model/reservation/request/reservation_approval_check_request_model.dart';
 import 'package:reservation_app/domain/model/reservation/reservation_detail_model.dart';
 import 'package:reservation_app/domain/model/reservation/reservation_non_auth_model.dart';
+import 'package:reservation_app/domain/model/sign/request/sign_out_request_model.dart';
 import 'package:reservation_app/domain/model/sign/sign_in_request_model.dart';
 
 extension MemberInfoResponseExtension on MemberInfoResponse {
@@ -97,6 +99,14 @@ extension ReservationDetailResponseExtension on ReservationDetailResponse {
       isUserValidation: isUserValidation,
       seats: seats,
       certificationNumber: certificationNumber,
+    );
+  }
+}
+
+extension SignOutRequestModelExtenstion on SignOutRequestModel {
+  SignOutRequest toSignOutRequestModel() {
+    return SignOutRequest(
+      memberId: memberId,
     );
   }
 }

--- a/lib/data/mapper/object_mapper.dart
+++ b/lib/data/mapper/object_mapper.dart
@@ -4,6 +4,8 @@ import 'package:reservation_app/data/model/reservation/page/reservation_filter_r
 import 'package:reservation_app/data/model/reservation/reservation_approval_check_request.dart';
 import 'package:reservation_app/data/model/reservation/reservation_detail_response.dart';
 import 'package:reservation_app/data/model/reservation/reservation_non_auth_response.dart';
+import 'package:reservation_app/data/model/reservation/reservation_range_section_data_response.dart';
+import 'package:reservation_app/data/model/reservation/reservation_range_section_response.dart';
 import 'package:reservation_app/data/model/sign/sign_in_request.dart';
 import 'package:reservation_app/data/model/sign/sign_out_request.dart';
 import 'package:reservation_app/domain/model/member/member_model.dart';
@@ -12,6 +14,8 @@ import 'package:reservation_app/domain/model/reservation/page/reservation_filter
 import 'package:reservation_app/domain/model/reservation/request/reservation_approval_check_request_model.dart';
 import 'package:reservation_app/domain/model/reservation/reservation_detail_model.dart';
 import 'package:reservation_app/domain/model/reservation/reservation_non_auth_model.dart';
+import 'package:reservation_app/domain/model/reservation/reservation_range_section_data_model.dart';
+import 'package:reservation_app/domain/model/reservation/reservation_range_section_model.dart';
 import 'package:reservation_app/domain/model/sign/request/sign_out_request_model.dart';
 import 'package:reservation_app/domain/model/sign/sign_in_request_model.dart';
 
@@ -104,9 +108,35 @@ extension ReservationDetailResponseExtension on ReservationDetailResponse {
 }
 
 extension SignOutRequestModelExtenstion on SignOutRequestModel {
-  SignOutRequest toSignOutRequestModel() {
+  SignOutRequest toSignOutRequest() {
     return SignOutRequest(
       memberId: memberId,
+    );
+  }
+}
+
+extension ReservationRangeSectionResponseExtension on ReservationRangeSectionResponse {
+  ReservationRangeSectionModel toReservationRangeSectionModel() {
+    return ReservationRangeSectionModel(
+      sectionTitle: sectionTitle,
+      partTime: partTime,
+      list: list.map((item) => item.toReservationRangeSectionDataModel()).toList()
+    );
+  }
+}
+
+extension ReservationRangeSectionDataResponseExtenstion on ReservationRangeSectionDataResponse {
+  ReservationRangeSectionDataModel toReservationRangeSectionDataModel() {
+    return ReservationRangeSectionDataModel(
+      id: id,
+      name: name,
+        phoneNumber: phoneNumber,
+        reservationDateTime: reservationDateTime,
+        reservationCount: reservationCount,
+        isTermAllAgree: isTermAllAgree,
+        isUserValidation: isUserValidation,
+        certificationNumber: certificationNumber,
+        partTime: partTime,
     );
   }
 }

--- a/lib/data/model/reservation/reservation_range_section_data_response.dart
+++ b/lib/data/model/reservation/reservation_range_section_data_response.dart
@@ -1,0 +1,23 @@
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:reservation_app/domain/model/reservation/enum/part_time.dart';
+
+part 'reservation_range_section_data_response.g.dart';
+part 'reservation_range_section_data_response.freezed.dart';
+
+@freezed
+class ReservationRangeSectionDataResponse with _$ReservationRangeSectionDataResponse {
+  factory ReservationRangeSectionDataResponse({
+    required int id,
+    required String name,
+    required String phoneNumber,
+    required String reservationDateTime,
+    required int reservationCount,
+    required bool isTermAllAgree,
+    required bool isUserValidation,
+    String? certificationNumber,
+    @JsonKey(name: 'timeType') required PartTime partTime,
+  }) = _ReservationRangeSectionDataResponse;
+
+  factory ReservationRangeSectionDataResponse.fromJson(Map<String, dynamic> json) => _$ReservationRangeSectionDataResponseFromJson(json);
+}

--- a/lib/data/model/reservation/reservation_range_section_data_response.freezed.dart
+++ b/lib/data/model/reservation/reservation_range_section_data_response.freezed.dart
@@ -1,0 +1,351 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'reservation_range_section_data_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+ReservationRangeSectionDataResponse
+    _$ReservationRangeSectionDataResponseFromJson(Map<String, dynamic> json) {
+  return _ReservationRangeSectionDataResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ReservationRangeSectionDataResponse {
+  int get id => throw _privateConstructorUsedError;
+  String get name => throw _privateConstructorUsedError;
+  String get phoneNumber => throw _privateConstructorUsedError;
+  String get reservationDateTime => throw _privateConstructorUsedError;
+  int get reservationCount => throw _privateConstructorUsedError;
+  bool get isTermAllAgree => throw _privateConstructorUsedError;
+  bool get isUserValidation => throw _privateConstructorUsedError;
+  String? get certificationNumber => throw _privateConstructorUsedError;
+  @JsonKey(name: 'timeType')
+  PartTime get partTime => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ReservationRangeSectionDataResponseCopyWith<
+          ReservationRangeSectionDataResponse>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReservationRangeSectionDataResponseCopyWith<$Res> {
+  factory $ReservationRangeSectionDataResponseCopyWith(
+          ReservationRangeSectionDataResponse value,
+          $Res Function(ReservationRangeSectionDataResponse) then) =
+      _$ReservationRangeSectionDataResponseCopyWithImpl<$Res,
+          ReservationRangeSectionDataResponse>;
+  @useResult
+  $Res call(
+      {int id,
+      String name,
+      String phoneNumber,
+      String reservationDateTime,
+      int reservationCount,
+      bool isTermAllAgree,
+      bool isUserValidation,
+      String? certificationNumber,
+      @JsonKey(name: 'timeType') PartTime partTime});
+}
+
+/// @nodoc
+class _$ReservationRangeSectionDataResponseCopyWithImpl<$Res,
+        $Val extends ReservationRangeSectionDataResponse>
+    implements $ReservationRangeSectionDataResponseCopyWith<$Res> {
+  _$ReservationRangeSectionDataResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? phoneNumber = null,
+    Object? reservationDateTime = null,
+    Object? reservationCount = null,
+    Object? isTermAllAgree = null,
+    Object? isUserValidation = null,
+    Object? certificationNumber = freezed,
+    Object? partTime = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      phoneNumber: null == phoneNumber
+          ? _value.phoneNumber
+          : phoneNumber // ignore: cast_nullable_to_non_nullable
+              as String,
+      reservationDateTime: null == reservationDateTime
+          ? _value.reservationDateTime
+          : reservationDateTime // ignore: cast_nullable_to_non_nullable
+              as String,
+      reservationCount: null == reservationCount
+          ? _value.reservationCount
+          : reservationCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      isTermAllAgree: null == isTermAllAgree
+          ? _value.isTermAllAgree
+          : isTermAllAgree // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isUserValidation: null == isUserValidation
+          ? _value.isUserValidation
+          : isUserValidation // ignore: cast_nullable_to_non_nullable
+              as bool,
+      certificationNumber: freezed == certificationNumber
+          ? _value.certificationNumber
+          : certificationNumber // ignore: cast_nullable_to_non_nullable
+              as String?,
+      partTime: null == partTime
+          ? _value.partTime
+          : partTime // ignore: cast_nullable_to_non_nullable
+              as PartTime,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_ReservationRangeSectionDataResponseCopyWith<$Res>
+    implements $ReservationRangeSectionDataResponseCopyWith<$Res> {
+  factory _$$_ReservationRangeSectionDataResponseCopyWith(
+          _$_ReservationRangeSectionDataResponse value,
+          $Res Function(_$_ReservationRangeSectionDataResponse) then) =
+      __$$_ReservationRangeSectionDataResponseCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {int id,
+      String name,
+      String phoneNumber,
+      String reservationDateTime,
+      int reservationCount,
+      bool isTermAllAgree,
+      bool isUserValidation,
+      String? certificationNumber,
+      @JsonKey(name: 'timeType') PartTime partTime});
+}
+
+/// @nodoc
+class __$$_ReservationRangeSectionDataResponseCopyWithImpl<$Res>
+    extends _$ReservationRangeSectionDataResponseCopyWithImpl<$Res,
+        _$_ReservationRangeSectionDataResponse>
+    implements _$$_ReservationRangeSectionDataResponseCopyWith<$Res> {
+  __$$_ReservationRangeSectionDataResponseCopyWithImpl(
+      _$_ReservationRangeSectionDataResponse _value,
+      $Res Function(_$_ReservationRangeSectionDataResponse) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? phoneNumber = null,
+    Object? reservationDateTime = null,
+    Object? reservationCount = null,
+    Object? isTermAllAgree = null,
+    Object? isUserValidation = null,
+    Object? certificationNumber = freezed,
+    Object? partTime = null,
+  }) {
+    return _then(_$_ReservationRangeSectionDataResponse(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      phoneNumber: null == phoneNumber
+          ? _value.phoneNumber
+          : phoneNumber // ignore: cast_nullable_to_non_nullable
+              as String,
+      reservationDateTime: null == reservationDateTime
+          ? _value.reservationDateTime
+          : reservationDateTime // ignore: cast_nullable_to_non_nullable
+              as String,
+      reservationCount: null == reservationCount
+          ? _value.reservationCount
+          : reservationCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      isTermAllAgree: null == isTermAllAgree
+          ? _value.isTermAllAgree
+          : isTermAllAgree // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isUserValidation: null == isUserValidation
+          ? _value.isUserValidation
+          : isUserValidation // ignore: cast_nullable_to_non_nullable
+              as bool,
+      certificationNumber: freezed == certificationNumber
+          ? _value.certificationNumber
+          : certificationNumber // ignore: cast_nullable_to_non_nullable
+              as String?,
+      partTime: null == partTime
+          ? _value.partTime
+          : partTime // ignore: cast_nullable_to_non_nullable
+              as PartTime,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_ReservationRangeSectionDataResponse
+    implements _ReservationRangeSectionDataResponse {
+  _$_ReservationRangeSectionDataResponse(
+      {required this.id,
+      required this.name,
+      required this.phoneNumber,
+      required this.reservationDateTime,
+      required this.reservationCount,
+      required this.isTermAllAgree,
+      required this.isUserValidation,
+      this.certificationNumber,
+      @JsonKey(name: 'timeType') required this.partTime});
+
+  factory _$_ReservationRangeSectionDataResponse.fromJson(
+          Map<String, dynamic> json) =>
+      _$$_ReservationRangeSectionDataResponseFromJson(json);
+
+  @override
+  final int id;
+  @override
+  final String name;
+  @override
+  final String phoneNumber;
+  @override
+  final String reservationDateTime;
+  @override
+  final int reservationCount;
+  @override
+  final bool isTermAllAgree;
+  @override
+  final bool isUserValidation;
+  @override
+  final String? certificationNumber;
+  @override
+  @JsonKey(name: 'timeType')
+  final PartTime partTime;
+
+  @override
+  String toString() {
+    return 'ReservationRangeSectionDataResponse(id: $id, name: $name, phoneNumber: $phoneNumber, reservationDateTime: $reservationDateTime, reservationCount: $reservationCount, isTermAllAgree: $isTermAllAgree, isUserValidation: $isUserValidation, certificationNumber: $certificationNumber, partTime: $partTime)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_ReservationRangeSectionDataResponse &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.phoneNumber, phoneNumber) ||
+                other.phoneNumber == phoneNumber) &&
+            (identical(other.reservationDateTime, reservationDateTime) ||
+                other.reservationDateTime == reservationDateTime) &&
+            (identical(other.reservationCount, reservationCount) ||
+                other.reservationCount == reservationCount) &&
+            (identical(other.isTermAllAgree, isTermAllAgree) ||
+                other.isTermAllAgree == isTermAllAgree) &&
+            (identical(other.isUserValidation, isUserValidation) ||
+                other.isUserValidation == isUserValidation) &&
+            (identical(other.certificationNumber, certificationNumber) ||
+                other.certificationNumber == certificationNumber) &&
+            (identical(other.partTime, partTime) ||
+                other.partTime == partTime));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      name,
+      phoneNumber,
+      reservationDateTime,
+      reservationCount,
+      isTermAllAgree,
+      isUserValidation,
+      certificationNumber,
+      partTime);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_ReservationRangeSectionDataResponseCopyWith<
+          _$_ReservationRangeSectionDataResponse>
+      get copyWith => __$$_ReservationRangeSectionDataResponseCopyWithImpl<
+          _$_ReservationRangeSectionDataResponse>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_ReservationRangeSectionDataResponseToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ReservationRangeSectionDataResponse
+    implements ReservationRangeSectionDataResponse {
+  factory _ReservationRangeSectionDataResponse(
+          {required final int id,
+          required final String name,
+          required final String phoneNumber,
+          required final String reservationDateTime,
+          required final int reservationCount,
+          required final bool isTermAllAgree,
+          required final bool isUserValidation,
+          final String? certificationNumber,
+          @JsonKey(name: 'timeType') required final PartTime partTime}) =
+      _$_ReservationRangeSectionDataResponse;
+
+  factory _ReservationRangeSectionDataResponse.fromJson(
+          Map<String, dynamic> json) =
+      _$_ReservationRangeSectionDataResponse.fromJson;
+
+  @override
+  int get id;
+  @override
+  String get name;
+  @override
+  String get phoneNumber;
+  @override
+  String get reservationDateTime;
+  @override
+  int get reservationCount;
+  @override
+  bool get isTermAllAgree;
+  @override
+  bool get isUserValidation;
+  @override
+  String? get certificationNumber;
+  @override
+  @JsonKey(name: 'timeType')
+  PartTime get partTime;
+  @override
+  @JsonKey(ignore: true)
+  _$$_ReservationRangeSectionDataResponseCopyWith<
+          _$_ReservationRangeSectionDataResponse>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/data/model/reservation/reservation_range_section_data_response.g.dart
+++ b/lib/data/model/reservation/reservation_range_section_data_response.g.dart
@@ -1,0 +1,42 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'reservation_range_section_data_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_ReservationRangeSectionDataResponse
+    _$$_ReservationRangeSectionDataResponseFromJson(
+            Map<String, dynamic> json) =>
+        _$_ReservationRangeSectionDataResponse(
+          id: json['id'] as int,
+          name: json['name'] as String,
+          phoneNumber: json['phoneNumber'] as String,
+          reservationDateTime: json['reservationDateTime'] as String,
+          reservationCount: json['reservationCount'] as int,
+          isTermAllAgree: json['isTermAllAgree'] as bool,
+          isUserValidation: json['isUserValidation'] as bool,
+          certificationNumber: json['certificationNumber'] as String?,
+          partTime: $enumDecode(_$PartTimeEnumMap, json['timeType']),
+        );
+
+Map<String, dynamic> _$$_ReservationRangeSectionDataResponseToJson(
+        _$_ReservationRangeSectionDataResponse instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'phoneNumber': instance.phoneNumber,
+      'reservationDateTime': instance.reservationDateTime,
+      'reservationCount': instance.reservationCount,
+      'isTermAllAgree': instance.isTermAllAgree,
+      'isUserValidation': instance.isUserValidation,
+      'certificationNumber': instance.certificationNumber,
+      'timeType': _$PartTimeEnumMap[instance.partTime]!,
+    };
+
+const _$PartTimeEnumMap = {
+  PartTime.partA: 'PART_A',
+  PartTime.partB: 'PART_B',
+  PartTime.partC: 'PART_C',
+};

--- a/lib/data/model/reservation/reservation_range_section_response.dart
+++ b/lib/data/model/reservation/reservation_range_section_response.dart
@@ -1,0 +1,18 @@
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:reservation_app/data/model/reservation/reservation_range_section_data_response.dart';
+import 'package:reservation_app/domain/model/reservation/enum/part_time.dart';
+
+part 'reservation_range_section_response.g.dart';
+part 'reservation_range_section_response.freezed.dart';
+
+@freezed
+class ReservationRangeSectionResponse with _$ReservationRangeSectionResponse {
+  factory ReservationRangeSectionResponse({
+    required String sectionTitle,
+    @JsonKey(name: 'timeType') required PartTime partTime,
+    required List<ReservationRangeSectionDataResponse> list,
+  }) = _ReservationRangeSectionResponse;
+
+  factory ReservationRangeSectionResponse.fromJson(Map<String, dynamic> json) => _$ReservationRangeSectionResponseFromJson(json);
+}

--- a/lib/data/model/reservation/reservation_range_section_response.freezed.dart
+++ b/lib/data/model/reservation/reservation_range_section_response.freezed.dart
@@ -1,0 +1,222 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'reservation_range_section_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+ReservationRangeSectionResponse _$ReservationRangeSectionResponseFromJson(
+    Map<String, dynamic> json) {
+  return _ReservationRangeSectionResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ReservationRangeSectionResponse {
+  String get sectionTitle => throw _privateConstructorUsedError;
+  @JsonKey(name: 'timeType')
+  PartTime get partTime => throw _privateConstructorUsedError;
+  List<ReservationRangeSectionDataResponse> get list =>
+      throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ReservationRangeSectionResponseCopyWith<ReservationRangeSectionResponse>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReservationRangeSectionResponseCopyWith<$Res> {
+  factory $ReservationRangeSectionResponseCopyWith(
+          ReservationRangeSectionResponse value,
+          $Res Function(ReservationRangeSectionResponse) then) =
+      _$ReservationRangeSectionResponseCopyWithImpl<$Res,
+          ReservationRangeSectionResponse>;
+  @useResult
+  $Res call(
+      {String sectionTitle,
+      @JsonKey(name: 'timeType') PartTime partTime,
+      List<ReservationRangeSectionDataResponse> list});
+}
+
+/// @nodoc
+class _$ReservationRangeSectionResponseCopyWithImpl<$Res,
+        $Val extends ReservationRangeSectionResponse>
+    implements $ReservationRangeSectionResponseCopyWith<$Res> {
+  _$ReservationRangeSectionResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? sectionTitle = null,
+    Object? partTime = null,
+    Object? list = null,
+  }) {
+    return _then(_value.copyWith(
+      sectionTitle: null == sectionTitle
+          ? _value.sectionTitle
+          : sectionTitle // ignore: cast_nullable_to_non_nullable
+              as String,
+      partTime: null == partTime
+          ? _value.partTime
+          : partTime // ignore: cast_nullable_to_non_nullable
+              as PartTime,
+      list: null == list
+          ? _value.list
+          : list // ignore: cast_nullable_to_non_nullable
+              as List<ReservationRangeSectionDataResponse>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_ReservationRangeSectionResponseCopyWith<$Res>
+    implements $ReservationRangeSectionResponseCopyWith<$Res> {
+  factory _$$_ReservationRangeSectionResponseCopyWith(
+          _$_ReservationRangeSectionResponse value,
+          $Res Function(_$_ReservationRangeSectionResponse) then) =
+      __$$_ReservationRangeSectionResponseCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String sectionTitle,
+      @JsonKey(name: 'timeType') PartTime partTime,
+      List<ReservationRangeSectionDataResponse> list});
+}
+
+/// @nodoc
+class __$$_ReservationRangeSectionResponseCopyWithImpl<$Res>
+    extends _$ReservationRangeSectionResponseCopyWithImpl<$Res,
+        _$_ReservationRangeSectionResponse>
+    implements _$$_ReservationRangeSectionResponseCopyWith<$Res> {
+  __$$_ReservationRangeSectionResponseCopyWithImpl(
+      _$_ReservationRangeSectionResponse _value,
+      $Res Function(_$_ReservationRangeSectionResponse) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? sectionTitle = null,
+    Object? partTime = null,
+    Object? list = null,
+  }) {
+    return _then(_$_ReservationRangeSectionResponse(
+      sectionTitle: null == sectionTitle
+          ? _value.sectionTitle
+          : sectionTitle // ignore: cast_nullable_to_non_nullable
+              as String,
+      partTime: null == partTime
+          ? _value.partTime
+          : partTime // ignore: cast_nullable_to_non_nullable
+              as PartTime,
+      list: null == list
+          ? _value._list
+          : list // ignore: cast_nullable_to_non_nullable
+              as List<ReservationRangeSectionDataResponse>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_ReservationRangeSectionResponse
+    implements _ReservationRangeSectionResponse {
+  _$_ReservationRangeSectionResponse(
+      {required this.sectionTitle,
+      @JsonKey(name: 'timeType') required this.partTime,
+      required final List<ReservationRangeSectionDataResponse> list})
+      : _list = list;
+
+  factory _$_ReservationRangeSectionResponse.fromJson(
+          Map<String, dynamic> json) =>
+      _$$_ReservationRangeSectionResponseFromJson(json);
+
+  @override
+  final String sectionTitle;
+  @override
+  @JsonKey(name: 'timeType')
+  final PartTime partTime;
+  final List<ReservationRangeSectionDataResponse> _list;
+  @override
+  List<ReservationRangeSectionDataResponse> get list {
+    if (_list is EqualUnmodifiableListView) return _list;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_list);
+  }
+
+  @override
+  String toString() {
+    return 'ReservationRangeSectionResponse(sectionTitle: $sectionTitle, partTime: $partTime, list: $list)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_ReservationRangeSectionResponse &&
+            (identical(other.sectionTitle, sectionTitle) ||
+                other.sectionTitle == sectionTitle) &&
+            (identical(other.partTime, partTime) ||
+                other.partTime == partTime) &&
+            const DeepCollectionEquality().equals(other._list, _list));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, sectionTitle, partTime,
+      const DeepCollectionEquality().hash(_list));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_ReservationRangeSectionResponseCopyWith<
+          _$_ReservationRangeSectionResponse>
+      get copyWith => __$$_ReservationRangeSectionResponseCopyWithImpl<
+          _$_ReservationRangeSectionResponse>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_ReservationRangeSectionResponseToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ReservationRangeSectionResponse
+    implements ReservationRangeSectionResponse {
+  factory _ReservationRangeSectionResponse(
+          {required final String sectionTitle,
+          @JsonKey(name: 'timeType') required final PartTime partTime,
+          required final List<ReservationRangeSectionDataResponse> list}) =
+      _$_ReservationRangeSectionResponse;
+
+  factory _ReservationRangeSectionResponse.fromJson(Map<String, dynamic> json) =
+      _$_ReservationRangeSectionResponse.fromJson;
+
+  @override
+  String get sectionTitle;
+  @override
+  @JsonKey(name: 'timeType')
+  PartTime get partTime;
+  @override
+  List<ReservationRangeSectionDataResponse> get list;
+  @override
+  @JsonKey(ignore: true)
+  _$$_ReservationRangeSectionResponseCopyWith<
+          _$_ReservationRangeSectionResponse>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/data/model/reservation/reservation_range_section_response.g.dart
+++ b/lib/data/model/reservation/reservation_range_section_response.g.dart
@@ -1,0 +1,32 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'reservation_range_section_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_ReservationRangeSectionResponse _$$_ReservationRangeSectionResponseFromJson(
+        Map<String, dynamic> json) =>
+    _$_ReservationRangeSectionResponse(
+      sectionTitle: json['sectionTitle'] as String,
+      partTime: $enumDecode(_$PartTimeEnumMap, json['timeType']),
+      list: (json['list'] as List<dynamic>)
+          .map((e) => ReservationRangeSectionDataResponse.fromJson(
+              e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$$_ReservationRangeSectionResponseToJson(
+        _$_ReservationRangeSectionResponse instance) =>
+    <String, dynamic>{
+      'sectionTitle': instance.sectionTitle,
+      'timeType': _$PartTimeEnumMap[instance.partTime]!,
+      'list': instance.list,
+    };
+
+const _$PartTimeEnumMap = {
+  PartTime.partA: 'PART_A',
+  PartTime.partB: 'PART_B',
+  PartTime.partC: 'PART_C',
+};

--- a/lib/data/model/sign/sign_in_response.dart
+++ b/lib/data/model/sign/sign_in_response.dart
@@ -20,5 +20,5 @@ class SignInResponse extends Equatable {
   Map<String, dynamic> toJson() => _$SignInResponseToJson(this);
 
   @override
-  List<Object?> get props => [];
+  List<Object?> get props => [token, refreshToken];
 }

--- a/lib/data/model/sign/sign_out_request.dart
+++ b/lib/data/model/sign/sign_out_request.dart
@@ -1,0 +1,24 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'sign_out_request.g.dart';
+
+@JsonSerializable()
+class SignOutRequest extends Equatable {
+  final int memberId;
+
+  SignOutRequest({
+    required this.memberId,
+  });
+
+  factory SignOutRequest.fromJson(Map<String, dynamic> json) =>
+    _$SignOutRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SignOutRequestToJson(this);
+
+  @override
+  List<Object?> get props => [memberId];
+
+  @override
+  bool? get stringify => false;
+}

--- a/lib/data/model/sign/sign_out_request.g.dart
+++ b/lib/data/model/sign/sign_out_request.g.dart
@@ -1,0 +1,17 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'sign_out_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+SignOutRequest _$SignOutRequestFromJson(Map<String, dynamic> json) =>
+    SignOutRequest(
+      memberId: json['memberId'] as int,
+    );
+
+Map<String, dynamic> _$SignOutRequestToJson(SignOutRequest instance) =>
+    <String, dynamic>{
+      'memberId': instance.memberId,
+    };

--- a/lib/data/repository/reservation/reservation_repository_impl.dart
+++ b/lib/data/repository/reservation/reservation_repository_impl.dart
@@ -7,6 +7,7 @@ import 'package:reservation_app/data/model/reservation/page/reservation_filter_l
 import 'package:reservation_app/data/model/reservation/reservation_create_request.dart';
 import 'package:reservation_app/data/model/reservation/reservation_detail_response.dart';
 import 'package:reservation_app/data/model/reservation/reservation_non_auth_response.dart';
+import 'package:reservation_app/data/model/reservation/reservation_range_section_response.dart';
 import 'package:reservation_app/data/model/reservation/reservation_target_date_response.dart';
 import 'package:reservation_app/di/prefs/shared_pref_module.dart';
 import 'package:reservation_app/domain/model/base/data_state.dart';
@@ -16,11 +17,14 @@ import 'package:reservation_app/domain/model/reservation/page/reservation_filter
 import 'package:reservation_app/domain/model/reservation/part_time_seat_list.dart';
 import 'package:reservation_app/domain/model/reservation/request/reservation_approval_check_request_model.dart';
 import 'package:reservation_app/domain/model/reservation/request/reservation_create_request_model.dart';
+import 'package:reservation_app/domain/model/reservation/request/reservation_date_range_req_model.dart';
 import 'package:reservation_app/domain/model/reservation/reservation_detail_model.dart';
 import 'package:reservation_app/domain/model/reservation/reservation_non_auth_model.dart';
+import 'package:reservation_app/domain/model/reservation/reservation_range_section_model.dart';
 import 'package:reservation_app/domain/model/reservation/reservation_target_date_model.dart';
 import 'package:reservation_app/domain/model/reservation/reservation_target_part_time_seat_model.dart';
 import 'package:reservation_app/domain/model/seat/enum/seat_type.dart';
+import 'package:reservation_app/presentation/utils/date_time_utils.dart';
 
 import '../../../domain/repository/reservation/reservation_repository.dart';
 
@@ -326,6 +330,44 @@ class ReservationRepositoryImpl implements ReservationRepository {
     } on DioException catch (error) {
       debugPrint(
           "🌹 GET [/reservation/user] API DioException 👉 ${error.message}");
+      final Map<String, dynamic>? responseData = error.response?.data;
+
+      if (responseData != null) {
+        final String? resultMsg = responseData['resultMsg'];
+        if (resultMsg != null) {
+          return DataNetworkError(resultMsg);
+        }
+      }
+
+      return DataError(error);
+    }
+  }
+
+  @override
+  Future<DataState<List<ReservationRangeSectionModel>>>
+      requestReservationRangeSectionList(
+    ReservationDateRangeReqModel request,
+  ) async {
+    try {
+      final response = await _remoteDataSource.requestReservationRangeList(
+        DateTimeUtils.dateTimeToYearDateString(request.searchStartDate),
+        DateTimeUtils.dateTimeToYearDateString(request.searchEndDate),
+      );
+
+      final List<ReservationRangeSectionResponse>? resultData = response.data;
+
+      if (response.success && response.code == 200 && resultData != null) {
+        return DataSuccess(
+          resultData
+              .map((item) => item.toReservationRangeSectionModel())
+              .toList(),
+        );
+      }
+
+      return DataNetworkError(response.resultMsg);
+    } on DioException catch (error) {
+      debugPrint(
+          "🌹 GET [/reservation/range] API DioException 👉 ${error.message}");
       final Map<String, dynamic>? responseData = error.response?.data;
 
       if (responseData != null) {

--- a/lib/data/repository/reservation/reservation_repository_impl.dart
+++ b/lib/data/repository/reservation/reservation_repository_impl.dart
@@ -350,8 +350,8 @@ class ReservationRepositoryImpl implements ReservationRepository {
   ) async {
     try {
       final response = await _remoteDataSource.requestReservationRangeList(
-        DateTimeUtils.dateTimeToYearDateString(request.searchStartDate),
-        DateTimeUtils.dateTimeToYearDateString(request.searchEndDate),
+        DateTimeUtils.dateTimeToAllDateString(request.searchStartDate),
+        DateTimeUtils.dateTimeToAllDateString(request.searchEndDate),
       );
 
       final List<ReservationRangeSectionResponse>? resultData = response.data;

--- a/lib/data/repository/sign/sign_repository_impl.dart
+++ b/lib/data/repository/sign/sign_repository_impl.dart
@@ -54,7 +54,7 @@ class SignRepositoryImpl implements SignRepository {
   Future<DataState<bool>> requestSignOut(SignOutRequestModel request) async {
     try {
       final response = await _remoteDataSource.requestSignOut(
-        request.toSignOutRequestModel(),
+        request.toSignOutRequest(),
       );
 
       if (response.success && response.code == 200) {

--- a/lib/data/repository/sign/sign_repository_impl.dart
+++ b/lib/data/repository/sign/sign_repository_impl.dart
@@ -7,6 +7,7 @@ import 'package:reservation_app/data/model/sign/phone_auth_request.dart';
 import 'package:reservation_app/data/model/sign/sign_in_response.dart';
 import 'package:reservation_app/di/prefs/shared_pref_module.dart';
 import 'package:reservation_app/domain/model/base/data_state.dart';
+import 'package:reservation_app/domain/model/sign/request/sign_out_request_model.dart';
 import 'package:reservation_app/domain/model/sign/sign_in_request_model.dart';
 import 'package:reservation_app/domain/repository/sign/sign_repository.dart';
 
@@ -50,9 +51,11 @@ class SignRepositoryImpl implements SignRepository {
   }
 
   @override
-  Future<DataState<bool>> requestSignOut() async {
+  Future<DataState<bool>> requestSignOut(SignOutRequestModel request) async {
     try {
-      final response = await _remoteDataSource.requestSignOut();
+      final response = await _remoteDataSource.requestSignOut(
+        request.toSignOutRequestModel(),
+      );
 
       if (response.success && response.code == 200) {
         await Future.wait([

--- a/lib/data/utils/Endpoints.dart
+++ b/lib/data/utils/Endpoints.dart
@@ -3,8 +3,10 @@ class Endpoints {
   Endpoints._();
 
   static const String baseUrl = "https://port-0-reservation-api-server-ah80fy2lll4tj3gi.sel3.cloudtype.app/api/v1";
+  // static const String baseUrl = "http://127.0.0.1:8080/api/v1";
 
   static const String baseImageUrl = "https://port-0-reservation-api-server-ah80fy2lll4tj3gi.sel3.cloudtype.app/image/";
+  // static const String baseImageUrl = "http://127.0.0.1:8080/image/";
 
   static const int receiveTimeout = 15000;
 

--- a/lib/di/dependency_injection_graph.dart
+++ b/lib/di/dependency_injection_graph.dart
@@ -273,6 +273,7 @@ Future<void> initializeDependencies() async {
   locator.registerFactory(
     () => ReservationCalendarTabBloc(
       locator<GetReservationRangeSectionListUseCase>(),
+      locator<GetTargetDateReservationUseCase>(),
     ),
   );
 }

--- a/lib/di/dependency_injection_graph.dart
+++ b/lib/di/dependency_injection_graph.dart
@@ -27,6 +27,7 @@ import 'package:reservation_app/domain/usecase/member/request_update_fcm_token_u
 import 'package:reservation_app/domain/usecase/notice/get_all_notice_list_use_case.dart';
 import 'package:reservation_app/domain/usecase/reservation/get_reservation_filter_page_list_use_case.dart';
 import 'package:reservation_app/domain/usecase/reservation/get_reservation_non_auth_list_use_case.dart';
+import 'package:reservation_app/domain/usecase/reservation/get_reservation_range_section_list_use_case.dart';
 import 'package:reservation_app/domain/usecase/reservation/get_reservation_target_part_time_use_case.dart';
 import 'package:reservation_app/domain/usecase/reservation/get_tartget_date_reservation_use_case.dart';
 import 'package:reservation_app/domain/usecase/reservation/request_approval_check_reservation_use_case.dart';
@@ -44,6 +45,7 @@ import 'package:reservation_app/presentation/views/main/tabs/home/bloc/home_tab_
 import 'package:reservation_app/presentation/views/main/tabs/home/tabs/home/bloc/content_home_tab_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/home/tabs/location/bloc/content_location_tab_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/home/tabs/notice/bloc/content_notice_tab_bloc.dart';
+import 'package:reservation_app/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/search/check/bloc/reservation_check_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/search/check/details/bloc/reservation_check_detail_bloc.dart';
 import 'package:reservation_app/presentation/views/network/bloc/network_bloc.dart';
@@ -196,6 +198,11 @@ Future<void> initializeDependencies() async {
       locator<ReservationRepository>(),
     ),
   );
+  locator.registerLazySingleton<GetReservationRangeSectionListUseCase>(
+    () => GetReservationRangeSectionListUseCase(
+      locator<ReservationRepository>(),
+    ),
+  );
 
   // 📌 Bloc
   locator.registerFactory(() => MainBloc());
@@ -261,6 +268,11 @@ Future<void> initializeDependencies() async {
       locator<RequestReservationDetailUseCase>(),
       locator<RequestReservationDetailByUserUseCase>(),
       locator<RequestApprovalCheckReservationUseCase>(),
+    ),
+  );
+  locator.registerFactory(
+    () => ReservationCalendarTabBloc(
+      locator<GetReservationRangeSectionListUseCase>(),
     ),
   );
 }

--- a/lib/domain/model/reservation/request/reservation_date_range_req_model.dart
+++ b/lib/domain/model/reservation/request/reservation_date_range_req_model.dart
@@ -1,0 +1,13 @@
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'reservation_date_range_req_model.freezed.dart';
+
+@freezed
+class ReservationDateRangeReqModel with _$ReservationDateRangeReqModel  {
+
+  factory ReservationDateRangeReqModel({
+    required DateTime searchStartDate,
+    required DateTime searchEndDate,
+  }) = _ReservationDateRangeReqModel;
+}

--- a/lib/domain/model/reservation/request/reservation_date_range_req_model.freezed.dart
+++ b/lib/domain/model/reservation/request/reservation_date_range_req_model.freezed.dart
@@ -1,0 +1,161 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'reservation_date_range_req_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$ReservationDateRangeReqModel {
+  DateTime get searchStartDate => throw _privateConstructorUsedError;
+  DateTime get searchEndDate => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ReservationDateRangeReqModelCopyWith<ReservationDateRangeReqModel>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReservationDateRangeReqModelCopyWith<$Res> {
+  factory $ReservationDateRangeReqModelCopyWith(
+          ReservationDateRangeReqModel value,
+          $Res Function(ReservationDateRangeReqModel) then) =
+      _$ReservationDateRangeReqModelCopyWithImpl<$Res,
+          ReservationDateRangeReqModel>;
+  @useResult
+  $Res call({DateTime searchStartDate, DateTime searchEndDate});
+}
+
+/// @nodoc
+class _$ReservationDateRangeReqModelCopyWithImpl<$Res,
+        $Val extends ReservationDateRangeReqModel>
+    implements $ReservationDateRangeReqModelCopyWith<$Res> {
+  _$ReservationDateRangeReqModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? searchStartDate = null,
+    Object? searchEndDate = null,
+  }) {
+    return _then(_value.copyWith(
+      searchStartDate: null == searchStartDate
+          ? _value.searchStartDate
+          : searchStartDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      searchEndDate: null == searchEndDate
+          ? _value.searchEndDate
+          : searchEndDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_ReservationDateRangeReqModelCopyWith<$Res>
+    implements $ReservationDateRangeReqModelCopyWith<$Res> {
+  factory _$$_ReservationDateRangeReqModelCopyWith(
+          _$_ReservationDateRangeReqModel value,
+          $Res Function(_$_ReservationDateRangeReqModel) then) =
+      __$$_ReservationDateRangeReqModelCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({DateTime searchStartDate, DateTime searchEndDate});
+}
+
+/// @nodoc
+class __$$_ReservationDateRangeReqModelCopyWithImpl<$Res>
+    extends _$ReservationDateRangeReqModelCopyWithImpl<$Res,
+        _$_ReservationDateRangeReqModel>
+    implements _$$_ReservationDateRangeReqModelCopyWith<$Res> {
+  __$$_ReservationDateRangeReqModelCopyWithImpl(
+      _$_ReservationDateRangeReqModel _value,
+      $Res Function(_$_ReservationDateRangeReqModel) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? searchStartDate = null,
+    Object? searchEndDate = null,
+  }) {
+    return _then(_$_ReservationDateRangeReqModel(
+      searchStartDate: null == searchStartDate
+          ? _value.searchStartDate
+          : searchStartDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      searchEndDate: null == searchEndDate
+          ? _value.searchEndDate
+          : searchEndDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_ReservationDateRangeReqModel implements _ReservationDateRangeReqModel {
+  _$_ReservationDateRangeReqModel(
+      {required this.searchStartDate, required this.searchEndDate});
+
+  @override
+  final DateTime searchStartDate;
+  @override
+  final DateTime searchEndDate;
+
+  @override
+  String toString() {
+    return 'ReservationDateRangeReqModel(searchStartDate: $searchStartDate, searchEndDate: $searchEndDate)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_ReservationDateRangeReqModel &&
+            (identical(other.searchStartDate, searchStartDate) ||
+                other.searchStartDate == searchStartDate) &&
+            (identical(other.searchEndDate, searchEndDate) ||
+                other.searchEndDate == searchEndDate));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, searchStartDate, searchEndDate);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_ReservationDateRangeReqModelCopyWith<_$_ReservationDateRangeReqModel>
+      get copyWith => __$$_ReservationDateRangeReqModelCopyWithImpl<
+          _$_ReservationDateRangeReqModel>(this, _$identity);
+}
+
+abstract class _ReservationDateRangeReqModel
+    implements ReservationDateRangeReqModel {
+  factory _ReservationDateRangeReqModel(
+      {required final DateTime searchStartDate,
+      required final DateTime searchEndDate}) = _$_ReservationDateRangeReqModel;
+
+  @override
+  DateTime get searchStartDate;
+  @override
+  DateTime get searchEndDate;
+  @override
+  @JsonKey(ignore: true)
+  _$$_ReservationDateRangeReqModelCopyWith<_$_ReservationDateRangeReqModel>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/domain/model/reservation/reservation_range_section_data_model.dart
+++ b/lib/domain/model/reservation/reservation_range_section_data_model.dart
@@ -1,0 +1,20 @@
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:reservation_app/domain/model/reservation/enum/part_time.dart';
+
+part 'reservation_range_section_data_model.freezed.dart';
+
+@freezed
+class ReservationRangeSectionDataModel with _$ReservationRangeSectionDataModel {
+  factory ReservationRangeSectionDataModel({
+    required int id,
+    required String name,
+    required String phoneNumber,
+    required String reservationDateTime,
+    required int reservationCount,
+    required bool isTermAllAgree,
+    required bool isUserValidation,
+    String? certificationNumber,
+    required PartTime partTime,
+  }) = _ReservationRangeSectionDataModel;
+}

--- a/lib/domain/model/reservation/reservation_range_section_data_model.freezed.dart
+++ b/lib/domain/model/reservation/reservation_range_section_data_model.freezed.dart
@@ -1,0 +1,324 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'reservation_range_section_data_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$ReservationRangeSectionDataModel {
+  int get id => throw _privateConstructorUsedError;
+  String get name => throw _privateConstructorUsedError;
+  String get phoneNumber => throw _privateConstructorUsedError;
+  String get reservationDateTime => throw _privateConstructorUsedError;
+  int get reservationCount => throw _privateConstructorUsedError;
+  bool get isTermAllAgree => throw _privateConstructorUsedError;
+  bool get isUserValidation => throw _privateConstructorUsedError;
+  String? get certificationNumber => throw _privateConstructorUsedError;
+  PartTime get partTime => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ReservationRangeSectionDataModelCopyWith<ReservationRangeSectionDataModel>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReservationRangeSectionDataModelCopyWith<$Res> {
+  factory $ReservationRangeSectionDataModelCopyWith(
+          ReservationRangeSectionDataModel value,
+          $Res Function(ReservationRangeSectionDataModel) then) =
+      _$ReservationRangeSectionDataModelCopyWithImpl<$Res,
+          ReservationRangeSectionDataModel>;
+  @useResult
+  $Res call(
+      {int id,
+      String name,
+      String phoneNumber,
+      String reservationDateTime,
+      int reservationCount,
+      bool isTermAllAgree,
+      bool isUserValidation,
+      String? certificationNumber,
+      PartTime partTime});
+}
+
+/// @nodoc
+class _$ReservationRangeSectionDataModelCopyWithImpl<$Res,
+        $Val extends ReservationRangeSectionDataModel>
+    implements $ReservationRangeSectionDataModelCopyWith<$Res> {
+  _$ReservationRangeSectionDataModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? phoneNumber = null,
+    Object? reservationDateTime = null,
+    Object? reservationCount = null,
+    Object? isTermAllAgree = null,
+    Object? isUserValidation = null,
+    Object? certificationNumber = freezed,
+    Object? partTime = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      phoneNumber: null == phoneNumber
+          ? _value.phoneNumber
+          : phoneNumber // ignore: cast_nullable_to_non_nullable
+              as String,
+      reservationDateTime: null == reservationDateTime
+          ? _value.reservationDateTime
+          : reservationDateTime // ignore: cast_nullable_to_non_nullable
+              as String,
+      reservationCount: null == reservationCount
+          ? _value.reservationCount
+          : reservationCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      isTermAllAgree: null == isTermAllAgree
+          ? _value.isTermAllAgree
+          : isTermAllAgree // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isUserValidation: null == isUserValidation
+          ? _value.isUserValidation
+          : isUserValidation // ignore: cast_nullable_to_non_nullable
+              as bool,
+      certificationNumber: freezed == certificationNumber
+          ? _value.certificationNumber
+          : certificationNumber // ignore: cast_nullable_to_non_nullable
+              as String?,
+      partTime: null == partTime
+          ? _value.partTime
+          : partTime // ignore: cast_nullable_to_non_nullable
+              as PartTime,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_ReservationRangeSectionDataModelCopyWith<$Res>
+    implements $ReservationRangeSectionDataModelCopyWith<$Res> {
+  factory _$$_ReservationRangeSectionDataModelCopyWith(
+          _$_ReservationRangeSectionDataModel value,
+          $Res Function(_$_ReservationRangeSectionDataModel) then) =
+      __$$_ReservationRangeSectionDataModelCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {int id,
+      String name,
+      String phoneNumber,
+      String reservationDateTime,
+      int reservationCount,
+      bool isTermAllAgree,
+      bool isUserValidation,
+      String? certificationNumber,
+      PartTime partTime});
+}
+
+/// @nodoc
+class __$$_ReservationRangeSectionDataModelCopyWithImpl<$Res>
+    extends _$ReservationRangeSectionDataModelCopyWithImpl<$Res,
+        _$_ReservationRangeSectionDataModel>
+    implements _$$_ReservationRangeSectionDataModelCopyWith<$Res> {
+  __$$_ReservationRangeSectionDataModelCopyWithImpl(
+      _$_ReservationRangeSectionDataModel _value,
+      $Res Function(_$_ReservationRangeSectionDataModel) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? phoneNumber = null,
+    Object? reservationDateTime = null,
+    Object? reservationCount = null,
+    Object? isTermAllAgree = null,
+    Object? isUserValidation = null,
+    Object? certificationNumber = freezed,
+    Object? partTime = null,
+  }) {
+    return _then(_$_ReservationRangeSectionDataModel(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      phoneNumber: null == phoneNumber
+          ? _value.phoneNumber
+          : phoneNumber // ignore: cast_nullable_to_non_nullable
+              as String,
+      reservationDateTime: null == reservationDateTime
+          ? _value.reservationDateTime
+          : reservationDateTime // ignore: cast_nullable_to_non_nullable
+              as String,
+      reservationCount: null == reservationCount
+          ? _value.reservationCount
+          : reservationCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      isTermAllAgree: null == isTermAllAgree
+          ? _value.isTermAllAgree
+          : isTermAllAgree // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isUserValidation: null == isUserValidation
+          ? _value.isUserValidation
+          : isUserValidation // ignore: cast_nullable_to_non_nullable
+              as bool,
+      certificationNumber: freezed == certificationNumber
+          ? _value.certificationNumber
+          : certificationNumber // ignore: cast_nullable_to_non_nullable
+              as String?,
+      partTime: null == partTime
+          ? _value.partTime
+          : partTime // ignore: cast_nullable_to_non_nullable
+              as PartTime,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_ReservationRangeSectionDataModel
+    implements _ReservationRangeSectionDataModel {
+  _$_ReservationRangeSectionDataModel(
+      {required this.id,
+      required this.name,
+      required this.phoneNumber,
+      required this.reservationDateTime,
+      required this.reservationCount,
+      required this.isTermAllAgree,
+      required this.isUserValidation,
+      this.certificationNumber,
+      required this.partTime});
+
+  @override
+  final int id;
+  @override
+  final String name;
+  @override
+  final String phoneNumber;
+  @override
+  final String reservationDateTime;
+  @override
+  final int reservationCount;
+  @override
+  final bool isTermAllAgree;
+  @override
+  final bool isUserValidation;
+  @override
+  final String? certificationNumber;
+  @override
+  final PartTime partTime;
+
+  @override
+  String toString() {
+    return 'ReservationRangeSectionDataModel(id: $id, name: $name, phoneNumber: $phoneNumber, reservationDateTime: $reservationDateTime, reservationCount: $reservationCount, isTermAllAgree: $isTermAllAgree, isUserValidation: $isUserValidation, certificationNumber: $certificationNumber, partTime: $partTime)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_ReservationRangeSectionDataModel &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.phoneNumber, phoneNumber) ||
+                other.phoneNumber == phoneNumber) &&
+            (identical(other.reservationDateTime, reservationDateTime) ||
+                other.reservationDateTime == reservationDateTime) &&
+            (identical(other.reservationCount, reservationCount) ||
+                other.reservationCount == reservationCount) &&
+            (identical(other.isTermAllAgree, isTermAllAgree) ||
+                other.isTermAllAgree == isTermAllAgree) &&
+            (identical(other.isUserValidation, isUserValidation) ||
+                other.isUserValidation == isUserValidation) &&
+            (identical(other.certificationNumber, certificationNumber) ||
+                other.certificationNumber == certificationNumber) &&
+            (identical(other.partTime, partTime) ||
+                other.partTime == partTime));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      name,
+      phoneNumber,
+      reservationDateTime,
+      reservationCount,
+      isTermAllAgree,
+      isUserValidation,
+      certificationNumber,
+      partTime);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_ReservationRangeSectionDataModelCopyWith<
+          _$_ReservationRangeSectionDataModel>
+      get copyWith => __$$_ReservationRangeSectionDataModelCopyWithImpl<
+          _$_ReservationRangeSectionDataModel>(this, _$identity);
+}
+
+abstract class _ReservationRangeSectionDataModel
+    implements ReservationRangeSectionDataModel {
+  factory _ReservationRangeSectionDataModel(
+      {required final int id,
+      required final String name,
+      required final String phoneNumber,
+      required final String reservationDateTime,
+      required final int reservationCount,
+      required final bool isTermAllAgree,
+      required final bool isUserValidation,
+      final String? certificationNumber,
+      required final PartTime partTime}) = _$_ReservationRangeSectionDataModel;
+
+  @override
+  int get id;
+  @override
+  String get name;
+  @override
+  String get phoneNumber;
+  @override
+  String get reservationDateTime;
+  @override
+  int get reservationCount;
+  @override
+  bool get isTermAllAgree;
+  @override
+  bool get isUserValidation;
+  @override
+  String? get certificationNumber;
+  @override
+  PartTime get partTime;
+  @override
+  @JsonKey(ignore: true)
+  _$$_ReservationRangeSectionDataModelCopyWith<
+          _$_ReservationRangeSectionDataModel>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/domain/model/reservation/reservation_range_section_model.dart
+++ b/lib/domain/model/reservation/reservation_range_section_model.dart
@@ -1,0 +1,15 @@
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:reservation_app/domain/model/reservation/enum/part_time.dart';
+import 'package:reservation_app/domain/model/reservation/reservation_range_section_data_model.dart';
+
+part 'reservation_range_section_model.freezed.dart';
+
+@freezed
+class ReservationRangeSectionModel with _$ReservationRangeSectionModel {
+  factory ReservationRangeSectionModel({
+    required String sectionTitle,
+    required PartTime partTime,
+    required List<ReservationRangeSectionDataModel> list,
+  }) = _ReservationRangeSectionModel;
+}

--- a/lib/domain/model/reservation/reservation_range_section_model.freezed.dart
+++ b/lib/domain/model/reservation/reservation_range_section_model.freezed.dart
@@ -1,0 +1,195 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'reservation_range_section_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$ReservationRangeSectionModel {
+  String get sectionTitle => throw _privateConstructorUsedError;
+  PartTime get partTime => throw _privateConstructorUsedError;
+  List<ReservationRangeSectionDataModel> get list =>
+      throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ReservationRangeSectionModelCopyWith<ReservationRangeSectionModel>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReservationRangeSectionModelCopyWith<$Res> {
+  factory $ReservationRangeSectionModelCopyWith(
+          ReservationRangeSectionModel value,
+          $Res Function(ReservationRangeSectionModel) then) =
+      _$ReservationRangeSectionModelCopyWithImpl<$Res,
+          ReservationRangeSectionModel>;
+  @useResult
+  $Res call(
+      {String sectionTitle,
+      PartTime partTime,
+      List<ReservationRangeSectionDataModel> list});
+}
+
+/// @nodoc
+class _$ReservationRangeSectionModelCopyWithImpl<$Res,
+        $Val extends ReservationRangeSectionModel>
+    implements $ReservationRangeSectionModelCopyWith<$Res> {
+  _$ReservationRangeSectionModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? sectionTitle = null,
+    Object? partTime = null,
+    Object? list = null,
+  }) {
+    return _then(_value.copyWith(
+      sectionTitle: null == sectionTitle
+          ? _value.sectionTitle
+          : sectionTitle // ignore: cast_nullable_to_non_nullable
+              as String,
+      partTime: null == partTime
+          ? _value.partTime
+          : partTime // ignore: cast_nullable_to_non_nullable
+              as PartTime,
+      list: null == list
+          ? _value.list
+          : list // ignore: cast_nullable_to_non_nullable
+              as List<ReservationRangeSectionDataModel>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_ReservationRangeSectionModelCopyWith<$Res>
+    implements $ReservationRangeSectionModelCopyWith<$Res> {
+  factory _$$_ReservationRangeSectionModelCopyWith(
+          _$_ReservationRangeSectionModel value,
+          $Res Function(_$_ReservationRangeSectionModel) then) =
+      __$$_ReservationRangeSectionModelCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String sectionTitle,
+      PartTime partTime,
+      List<ReservationRangeSectionDataModel> list});
+}
+
+/// @nodoc
+class __$$_ReservationRangeSectionModelCopyWithImpl<$Res>
+    extends _$ReservationRangeSectionModelCopyWithImpl<$Res,
+        _$_ReservationRangeSectionModel>
+    implements _$$_ReservationRangeSectionModelCopyWith<$Res> {
+  __$$_ReservationRangeSectionModelCopyWithImpl(
+      _$_ReservationRangeSectionModel _value,
+      $Res Function(_$_ReservationRangeSectionModel) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? sectionTitle = null,
+    Object? partTime = null,
+    Object? list = null,
+  }) {
+    return _then(_$_ReservationRangeSectionModel(
+      sectionTitle: null == sectionTitle
+          ? _value.sectionTitle
+          : sectionTitle // ignore: cast_nullable_to_non_nullable
+              as String,
+      partTime: null == partTime
+          ? _value.partTime
+          : partTime // ignore: cast_nullable_to_non_nullable
+              as PartTime,
+      list: null == list
+          ? _value._list
+          : list // ignore: cast_nullable_to_non_nullable
+              as List<ReservationRangeSectionDataModel>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_ReservationRangeSectionModel implements _ReservationRangeSectionModel {
+  _$_ReservationRangeSectionModel(
+      {required this.sectionTitle,
+      required this.partTime,
+      required final List<ReservationRangeSectionDataModel> list})
+      : _list = list;
+
+  @override
+  final String sectionTitle;
+  @override
+  final PartTime partTime;
+  final List<ReservationRangeSectionDataModel> _list;
+  @override
+  List<ReservationRangeSectionDataModel> get list {
+    if (_list is EqualUnmodifiableListView) return _list;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_list);
+  }
+
+  @override
+  String toString() {
+    return 'ReservationRangeSectionModel(sectionTitle: $sectionTitle, partTime: $partTime, list: $list)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_ReservationRangeSectionModel &&
+            (identical(other.sectionTitle, sectionTitle) ||
+                other.sectionTitle == sectionTitle) &&
+            (identical(other.partTime, partTime) ||
+                other.partTime == partTime) &&
+            const DeepCollectionEquality().equals(other._list, _list));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, sectionTitle, partTime,
+      const DeepCollectionEquality().hash(_list));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_ReservationRangeSectionModelCopyWith<_$_ReservationRangeSectionModel>
+      get copyWith => __$$_ReservationRangeSectionModelCopyWithImpl<
+          _$_ReservationRangeSectionModel>(this, _$identity);
+}
+
+abstract class _ReservationRangeSectionModel
+    implements ReservationRangeSectionModel {
+  factory _ReservationRangeSectionModel(
+          {required final String sectionTitle,
+          required final PartTime partTime,
+          required final List<ReservationRangeSectionDataModel> list}) =
+      _$_ReservationRangeSectionModel;
+
+  @override
+  String get sectionTitle;
+  @override
+  PartTime get partTime;
+  @override
+  List<ReservationRangeSectionDataModel> get list;
+  @override
+  @JsonKey(ignore: true)
+  _$$_ReservationRangeSectionModelCopyWith<_$_ReservationRangeSectionModel>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/domain/model/sign/request/sign_out_request_model.dart
+++ b/lib/domain/model/sign/request/sign_out_request_model.dart
@@ -1,0 +1,15 @@
+
+import 'package:equatable/equatable.dart';
+
+class SignOutRequestModel extends Equatable {
+  final int memberId;
+  const SignOutRequestModel({
+    required this.memberId,
+  });
+
+  @override
+  List<Object?> get props => [memberId];
+
+  @override
+  bool? get stringify => false;
+}

--- a/lib/domain/repository/reservation/reservation_repository.dart
+++ b/lib/domain/repository/reservation/reservation_repository.dart
@@ -3,8 +3,10 @@ import 'package:reservation_app/domain/model/reservation/enum/reservation_filter
 import 'package:reservation_app/domain/model/reservation/page/reservation_filter_list_model.dart';
 import 'package:reservation_app/domain/model/reservation/request/reservation_approval_check_request_model.dart';
 import 'package:reservation_app/domain/model/reservation/request/reservation_create_request_model.dart';
+import 'package:reservation_app/domain/model/reservation/request/reservation_date_range_req_model.dart';
 import 'package:reservation_app/domain/model/reservation/reservation_detail_model.dart';
 import 'package:reservation_app/domain/model/reservation/reservation_non_auth_model.dart';
+import 'package:reservation_app/domain/model/reservation/reservation_range_section_model.dart';
 import 'package:reservation_app/domain/model/reservation/reservation_target_date_model.dart';
 import 'package:reservation_app/domain/model/reservation/reservation_target_part_time_seat_model.dart';
 
@@ -44,5 +46,10 @@ abstract class ReservationRepository {
 
   Future<DataState<ReservationDetailModel>> requestReservationDetailByUser(
     String certificationNumber,
+  );
+
+  Future<DataState<List<ReservationRangeSectionModel>>>
+      requestReservationRangeSectionList(
+    ReservationDateRangeReqModel request,
   );
 }

--- a/lib/domain/repository/sign/sign_repository.dart
+++ b/lib/domain/repository/sign/sign_repository.dart
@@ -2,13 +2,14 @@
 import 'package:reservation_app/data/model/sign/phone_auth_check_request.dart';
 import 'package:reservation_app/data/model/sign/phone_auth_request.dart';
 import 'package:reservation_app/domain/model/base/data_state.dart';
+import 'package:reservation_app/domain/model/sign/request/sign_out_request_model.dart';
 import 'package:reservation_app/domain/model/sign/sign_in_request_model.dart';
 
 abstract class SignRepository {
 
   Future<DataState<bool>> requestSignIn(SignInRequestModel request);
 
-  Future<DataState<bool>> requestSignOut();
+  Future<DataState<bool>> requestSignOut(SignOutRequestModel request);
 
   Future<DataState<bool>> getAuthenticationNumber(PhoneAuthRequest request);
 

--- a/lib/domain/usecase/reservation/get_reservation_range_section_list_use_case.dart
+++ b/lib/domain/usecase/reservation/get_reservation_range_section_list_use_case.dart
@@ -1,0 +1,14 @@
+
+import 'package:reservation_app/domain/model/base/data_state.dart';
+import 'package:reservation_app/domain/model/reservation/request/reservation_date_range_req_model.dart';
+import 'package:reservation_app/domain/model/reservation/reservation_range_section_model.dart';
+import 'package:reservation_app/domain/repository/reservation/reservation_repository.dart';
+
+class GetReservationRangeSectionListUseCase {
+  final ReservationRepository _reservationRepository;
+  GetReservationRangeSectionListUseCase(this._reservationRepository);
+
+  Future<DataState<List<ReservationRangeSectionModel>>> invoke(ReservationDateRangeReqModel request) {
+    return _reservationRepository.requestReservationRangeSectionList(request);
+  }
+}

--- a/lib/domain/usecase/sign/request_sign_out_use_case.dart
+++ b/lib/domain/usecase/sign/request_sign_out_use_case.dart
@@ -1,5 +1,6 @@
 
 import 'package:reservation_app/domain/model/base/data_state.dart';
+import 'package:reservation_app/domain/model/sign/request/sign_out_request_model.dart';
 import 'package:reservation_app/domain/repository/sign/sign_repository.dart';
 
 class RequestSignOutUseCase {
@@ -7,7 +8,7 @@ class RequestSignOutUseCase {
 
   RequestSignOutUseCase(this._signRepository);
 
-  Future<DataState<bool>> invoke() {
-    return _signRepository.requestSignOut();
+  Future<DataState<bool>> invoke(SignOutRequestModel request) {
+    return _signRepository.requestSignOut(request);
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:reservation_app/presentation/views/main/bloc/main_bloc.dart';
 import 'package:reservation_app/presentation/views/network/bloc/network_bloc.dart';
 import 'package:reservation_app/presentation/views/sign/bloc/sign_bloc.dart';
 import 'package:reservation_app/presentation/views/user/bloc/user_info_bloc.dart';
+import 'package:intl/date_symbol_data_local.dart';
 
 import 'di/dependency_injection_graph.dart';
 import 'firebase_options.dart';
@@ -33,6 +34,8 @@ void main() async {
       onAuthFailed: (error) {
         debugPrint('💛 Naver ClientId Auth failed 👉 $error');
       });
+
+  await initializeDateFormatting();
 
   runApp(const MyApp());
 }

--- a/lib/presentation/utils/color_constants.dart
+++ b/lib/presentation/utils/color_constants.dart
@@ -60,6 +60,7 @@ class ColorsConstants {
   static const Color calendarPickerColor = Color(0xFF6A92B4);
   static const Color calendarSideColor = Color(0xFF7C9BB4);
   static const Color calendarCurrentColor = Color(0xFFE8CCB4);
+  static const Color calendarRangeColor = Color(0xFFE8CCC4);
 
   // Dialog
   static const Color dialogBackground = Color(0x55000000);

--- a/lib/presentation/utils/color_constants.dart
+++ b/lib/presentation/utils/color_constants.dart
@@ -23,6 +23,15 @@ class ColorsConstants {
   static const Color tabBarSelectedIcon = Color(0xFFed5463);
   static const Color tabBarUnselectedIcon = Color(0xFFed5463);
 
+  static const Color test = Color(0xffffd7a6);
+  static const Color test1 = Color(0xffffdecb);
+  static const Color test2 = Color(0xffffc8c3);
+
+  // partTime
+  static const Color partTimeA = Color(0xfff0be58);
+  static const Color partTimeB = Color(0xffe8ba86);
+  static const Color partTimeC = Color(0xffce8477);
+
   // Texts
   static const Color text = Color(0xFFFFFFFF);
   static const Color textDark = Color(0xFFFFFFFF);
@@ -38,6 +47,8 @@ class ColorsConstants {
   static const Color strokeGray = Color(0xFFD7D7D7);
   static const Color rightActionButton = Color(0xFFA5A5A5);
   static const Color clown = Color(0xFFFFF3B4);
+  static const Color currentDate = Color(0xFFB5DCF9);
+  static const Color selectedDate = Color(0xFFBCCEF4);
 
   // Others Widgets
   static const Color card = Color(0x20FFFFFF);

--- a/lib/presentation/utils/color_constants.dart
+++ b/lib/presentation/utils/color_constants.dart
@@ -1,6 +1,8 @@
 
 import 'dart:ui';
 
+import 'package:reservation_app/domain/model/reservation/enum/part_time.dart';
+
 class ColorsConstants {
   // App Colors
   static const Color primary = Color(0xffed5463);
@@ -75,4 +77,17 @@ class ColorsConstants {
 
   // Dialog
   static const Color dialogBackground = Color(0x55000000);
+
+  static Color getParTimeColor(PartTime partTime) {
+    switch (partTime) {
+      case PartTime.partA:
+        return ColorsConstants.partTimeA;
+      case PartTime.partB:
+        return ColorsConstants.partTimeB;
+      case PartTime.partC:
+        return ColorsConstants.partTimeC;
+      default:
+        return ColorsConstants.background;
+    }
+  }
 }

--- a/lib/presentation/utils/date_time_utils.dart
+++ b/lib/presentation/utils/date_time_utils.dart
@@ -86,6 +86,11 @@ class DateTimeUtils {
     return '$period $formattedTime';
   }
 
+  static String dateTimeToAllDateString(DateTime dateTime) {
+    const isoFormat = "yyyy-MM-dd'T'HH:mm:ss";
+    return DateFormat(isoFormat).format(dateTime);
+  }
+
   static String dateTimeToYearDateString(DateTime dateTime) {
     return DateFormat('yyyy-MM-dd').format(dateTime);
   }

--- a/lib/presentation/utils/date_time_utils.dart
+++ b/lib/presentation/utils/date_time_utils.dart
@@ -85,4 +85,8 @@ class DateTimeUtils {
 
     return '$period $formattedTime';
   }
+
+  static String dateTimeToYearDateString(DateTime dateTime) {
+    return DateFormat('yyyy-MM-dd').format(dateTime);
+  }
 }

--- a/lib/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_bloc.dart
+++ b/lib/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_bloc.dart
@@ -43,17 +43,21 @@ class ReservationCalendarTabBloc
   ) {
     final now = DateTime.now();
 
-    // 📌 아래와 같이 넣어야지 현재 달의 첫 날부터 마지막 날까지의 데이터를 가져옴
+    // 달력 데이터를 처음 가져올때만 Loading Dialog 를 보여주기 위해 여기서 Loading 처리
+    emit(state.copyWith(sectionListStatus: SectionListStatus.loading));
+
+    /// 📌 아래와 같이 넣어야지 현재 달의 첫 날부터 마지막 날까지의 데이터를 가져옴
+    /// 📍 그 전달의 데이터와 이번달의 데이터 그리고 다음달의 데이터 총 3달의 데이터를 가져옴
     add(
       ReservationCalendarTabSectionListEvent(
         startTime: DateTime(
-          now.year, // 현재 달의 첫 번째 날
-          now.month, // 다음 달의 첫 번째 날
+          now.year,
+          now.month - 1,
           1,
         ),
         endTime: DateTime(
           now.year,
-          now.month + 1,
+          now.month + 2,
           1,
         ),
       ),
@@ -64,8 +68,6 @@ class ReservationCalendarTabBloc
     ReservationCalendarTabSectionListEvent event,
     Emitter<ReservationCalendarTabState> emit,
   ) async {
-    emit(state.copyWith(sectionListStatus: SectionListStatus.loading));
-
     debugPrint(
       "📅 event.startTime 👉 ${DateTimeUtils.dateTimeToYearDateString(event.startTime)}",
     );

--- a/lib/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_bloc.dart
+++ b/lib/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_bloc.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:reservation_app/domain/model/base/data_state.dart';
+import 'package:reservation_app/domain/model/reservation/request/reservation_date_range_req_model.dart';
+import 'package:reservation_app/domain/model/reservation/reservation_range_section_model.dart';
+import 'package:reservation_app/domain/usecase/reservation/get_reservation_range_section_list_use_case.dart';
+import 'package:reservation_app/presentation/utils/constants.dart';
+import 'package:reservation_app/presentation/utils/date_time_utils.dart';
+
+part 'reservation_calendar_tab_bloc.freezed.dart';
+
+part 'reservation_calendar_tab_event.dart';
+
+part 'reservation_calendar_tab_state.dart';
+
+class ReservationCalendarTabBloc
+    extends Bloc<ReservationCalendarTabEvent, ReservationCalendarTabState> {
+  final GetReservationRangeSectionListUseCase _getReservationRangeSectionListUseCase;
+
+  ReservationCalendarTabBloc(
+    this._getReservationRangeSectionListUseCase,
+  ) : super(ReservationCalendarTabState()) {
+    on<ReservationCalendarTabInitDataEvent>(
+      (event, emit) => _getInitData(
+        event,
+        emit,
+      ),
+    );
+    on<ReservationCalendarTabSectionListEvent>(
+      (event, emit) => _getSectionList(
+        event,
+        emit,
+      ),
+    );
+  }
+
+  void _getInitData(
+    ReservationCalendarTabInitDataEvent event,
+    Emitter<ReservationCalendarTabState> emit,
+  ) {
+    final now = DateTime.now();
+
+    // 📌 아래와 같이 넣어야지 현재 달의 첫 날부터 마지막 날까지의 데이터를 가져옴
+    add(
+      ReservationCalendarTabSectionListEvent(
+        startTime: DateTime(
+          now.year, // 현재 달의 첫 번째 날
+          now.month, // 다음 달의 첫 번째 날
+          1,
+        ),
+        endTime: DateTime(
+          now.year,
+          now.month + 1,
+          1,
+        ),
+      ),
+    );
+  }
+
+  FutureOr<void> _getSectionList(
+    ReservationCalendarTabSectionListEvent event,
+    Emitter<ReservationCalendarTabState> emit,
+  ) async {
+    emit(state.copyWith(sectionListStatus: SectionListStatus.loading));
+
+    debugPrint(
+      "📅 event.startTime 👉 ${DateTimeUtils.dateTimeToYearDateString(event.startTime)}",
+    );
+    debugPrint(
+      "📅 event.endTime 👉 ${DateTimeUtils.dateTimeToYearDateString(event.endTime)}",
+    );
+    final response = await _getReservationRangeSectionListUseCase.invoke(
+      ReservationDateRangeReqModel(
+        searchStartDate: event.startTime,
+        searchEndDate: event.endTime,
+      ),
+    );
+
+    if (response is DataSuccess) {
+      final result = response.data;
+
+      if (result != null) {
+        emit(
+          state.copyWith(
+            sectionListStatus: SectionListStatus.success,
+            sectionList: result,
+            sectionListErrorMsg: null,
+          ),
+        );
+      } else {
+        emit(
+          state.copyWith(
+            sectionListStatus: SectionListStatus.error,
+            sectionList: [],
+            sectionListErrorMsg: Constants.networkError,
+          ),
+        );
+      }
+    } else if (response is DataNetworkError) {
+      emit(
+        state.copyWith(
+          sectionListStatus: SectionListStatus.error,
+          sectionList: [],
+          sectionListErrorMsg: response.message ?? Constants.networkError,
+        ),
+      );
+    } else if (response is DataError) {
+      emit(
+        state.copyWith(
+          sectionListStatus: SectionListStatus.error,
+          sectionList: [],
+          sectionListErrorMsg: response.message ?? Constants.dataError,
+        ),
+      );
+    } else {
+      emit(
+        state.copyWith(
+          sectionListStatus: SectionListStatus.error,
+          sectionList: [],
+          sectionListErrorMsg: Constants.dataError,
+        ),
+      );
+    }
+  }
+}

--- a/lib/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_bloc.freezed.dart
+++ b/lib/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_bloc.freezed.dart
@@ -20,18 +20,24 @@ mixin _$ReservationCalendarTabEvent {
   TResult when<TResult extends Object?>({
     required TResult Function() initData,
     required TResult Function(DateTime startTime, DateTime endTime) sectionList,
+    required TResult Function(DateTime targetDate) targetList,
+    required TResult Function() resetTargetList,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? initData,
     TResult? Function(DateTime startTime, DateTime endTime)? sectionList,
+    TResult? Function(DateTime targetDate)? targetList,
+    TResult? Function()? resetTargetList,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? initData,
     TResult Function(DateTime startTime, DateTime endTime)? sectionList,
+    TResult Function(DateTime targetDate)? targetList,
+    TResult Function()? resetTargetList,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -41,6 +47,10 @@ mixin _$ReservationCalendarTabEvent {
         initData,
     required TResult Function(ReservationCalendarTabSectionListEvent value)
         sectionList,
+    required TResult Function(ReservationCalendarTabTargetListEvent value)
+        targetList,
+    required TResult Function(ReservationCalendarTabResetTargetListEvent value)
+        resetTargetList,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -48,12 +58,18 @@ mixin _$ReservationCalendarTabEvent {
     TResult? Function(ReservationCalendarTabInitDataEvent value)? initData,
     TResult? Function(ReservationCalendarTabSectionListEvent value)?
         sectionList,
+    TResult? Function(ReservationCalendarTabTargetListEvent value)? targetList,
+    TResult? Function(ReservationCalendarTabResetTargetListEvent value)?
+        resetTargetList,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
     TResult Function(ReservationCalendarTabInitDataEvent value)? initData,
     TResult Function(ReservationCalendarTabSectionListEvent value)? sectionList,
+    TResult Function(ReservationCalendarTabTargetListEvent value)? targetList,
+    TResult Function(ReservationCalendarTabResetTargetListEvent value)?
+        resetTargetList,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -133,6 +149,8 @@ class _$ReservationCalendarTabInitDataEvent
   TResult when<TResult extends Object?>({
     required TResult Function() initData,
     required TResult Function(DateTime startTime, DateTime endTime) sectionList,
+    required TResult Function(DateTime targetDate) targetList,
+    required TResult Function() resetTargetList,
   }) {
     return initData();
   }
@@ -142,6 +160,8 @@ class _$ReservationCalendarTabInitDataEvent
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? initData,
     TResult? Function(DateTime startTime, DateTime endTime)? sectionList,
+    TResult? Function(DateTime targetDate)? targetList,
+    TResult? Function()? resetTargetList,
   }) {
     return initData?.call();
   }
@@ -151,6 +171,8 @@ class _$ReservationCalendarTabInitDataEvent
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? initData,
     TResult Function(DateTime startTime, DateTime endTime)? sectionList,
+    TResult Function(DateTime targetDate)? targetList,
+    TResult Function()? resetTargetList,
     required TResult orElse(),
   }) {
     if (initData != null) {
@@ -166,6 +188,10 @@ class _$ReservationCalendarTabInitDataEvent
         initData,
     required TResult Function(ReservationCalendarTabSectionListEvent value)
         sectionList,
+    required TResult Function(ReservationCalendarTabTargetListEvent value)
+        targetList,
+    required TResult Function(ReservationCalendarTabResetTargetListEvent value)
+        resetTargetList,
   }) {
     return initData(this);
   }
@@ -176,6 +202,9 @@ class _$ReservationCalendarTabInitDataEvent
     TResult? Function(ReservationCalendarTabInitDataEvent value)? initData,
     TResult? Function(ReservationCalendarTabSectionListEvent value)?
         sectionList,
+    TResult? Function(ReservationCalendarTabTargetListEvent value)? targetList,
+    TResult? Function(ReservationCalendarTabResetTargetListEvent value)?
+        resetTargetList,
   }) {
     return initData?.call(this);
   }
@@ -185,6 +214,9 @@ class _$ReservationCalendarTabInitDataEvent
   TResult maybeMap<TResult extends Object?>({
     TResult Function(ReservationCalendarTabInitDataEvent value)? initData,
     TResult Function(ReservationCalendarTabSectionListEvent value)? sectionList,
+    TResult Function(ReservationCalendarTabTargetListEvent value)? targetList,
+    TResult Function(ReservationCalendarTabResetTargetListEvent value)?
+        resetTargetList,
     required TResult orElse(),
   }) {
     if (initData != null) {
@@ -293,6 +325,8 @@ class _$ReservationCalendarTabSectionListEvent
   TResult when<TResult extends Object?>({
     required TResult Function() initData,
     required TResult Function(DateTime startTime, DateTime endTime) sectionList,
+    required TResult Function(DateTime targetDate) targetList,
+    required TResult Function() resetTargetList,
   }) {
     return sectionList(startTime, endTime);
   }
@@ -302,6 +336,8 @@ class _$ReservationCalendarTabSectionListEvent
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? initData,
     TResult? Function(DateTime startTime, DateTime endTime)? sectionList,
+    TResult? Function(DateTime targetDate)? targetList,
+    TResult? Function()? resetTargetList,
   }) {
     return sectionList?.call(startTime, endTime);
   }
@@ -311,6 +347,8 @@ class _$ReservationCalendarTabSectionListEvent
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? initData,
     TResult Function(DateTime startTime, DateTime endTime)? sectionList,
+    TResult Function(DateTime targetDate)? targetList,
+    TResult Function()? resetTargetList,
     required TResult orElse(),
   }) {
     if (sectionList != null) {
@@ -326,6 +364,10 @@ class _$ReservationCalendarTabSectionListEvent
         initData,
     required TResult Function(ReservationCalendarTabSectionListEvent value)
         sectionList,
+    required TResult Function(ReservationCalendarTabTargetListEvent value)
+        targetList,
+    required TResult Function(ReservationCalendarTabResetTargetListEvent value)
+        resetTargetList,
   }) {
     return sectionList(this);
   }
@@ -336,6 +378,9 @@ class _$ReservationCalendarTabSectionListEvent
     TResult? Function(ReservationCalendarTabInitDataEvent value)? initData,
     TResult? Function(ReservationCalendarTabSectionListEvent value)?
         sectionList,
+    TResult? Function(ReservationCalendarTabTargetListEvent value)? targetList,
+    TResult? Function(ReservationCalendarTabResetTargetListEvent value)?
+        resetTargetList,
   }) {
     return sectionList?.call(this);
   }
@@ -345,6 +390,9 @@ class _$ReservationCalendarTabSectionListEvent
   TResult maybeMap<TResult extends Object?>({
     TResult Function(ReservationCalendarTabInitDataEvent value)? initData,
     TResult Function(ReservationCalendarTabSectionListEvent value)? sectionList,
+    TResult Function(ReservationCalendarTabTargetListEvent value)? targetList,
+    TResult Function(ReservationCalendarTabResetTargetListEvent value)?
+        resetTargetList,
     required TResult orElse(),
   }) {
     if (sectionList != null) {
@@ -370,11 +418,324 @@ abstract class ReservationCalendarTabSectionListEvent
 }
 
 /// @nodoc
+abstract class _$$ReservationCalendarTabTargetListEventCopyWith<$Res> {
+  factory _$$ReservationCalendarTabTargetListEventCopyWith(
+          _$ReservationCalendarTabTargetListEvent value,
+          $Res Function(_$ReservationCalendarTabTargetListEvent) then) =
+      __$$ReservationCalendarTabTargetListEventCopyWithImpl<$Res>;
+  @useResult
+  $Res call({DateTime targetDate});
+}
+
+/// @nodoc
+class __$$ReservationCalendarTabTargetListEventCopyWithImpl<$Res>
+    extends _$ReservationCalendarTabEventCopyWithImpl<$Res,
+        _$ReservationCalendarTabTargetListEvent>
+    implements _$$ReservationCalendarTabTargetListEventCopyWith<$Res> {
+  __$$ReservationCalendarTabTargetListEventCopyWithImpl(
+      _$ReservationCalendarTabTargetListEvent _value,
+      $Res Function(_$ReservationCalendarTabTargetListEvent) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? targetDate = null,
+  }) {
+    return _then(_$ReservationCalendarTabTargetListEvent(
+      targetDate: null == targetDate
+          ? _value.targetDate
+          : targetDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ReservationCalendarTabTargetListEvent
+    with DiagnosticableTreeMixin
+    implements ReservationCalendarTabTargetListEvent {
+  const _$ReservationCalendarTabTargetListEvent({required this.targetDate});
+
+  @override
+  final DateTime targetDate;
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'ReservationCalendarTabEvent.targetList(targetDate: $targetDate)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(
+          DiagnosticsProperty('type', 'ReservationCalendarTabEvent.targetList'))
+      ..add(DiagnosticsProperty('targetDate', targetDate));
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReservationCalendarTabTargetListEvent &&
+            (identical(other.targetDate, targetDate) ||
+                other.targetDate == targetDate));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, targetDate);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ReservationCalendarTabTargetListEventCopyWith<
+          _$ReservationCalendarTabTargetListEvent>
+      get copyWith => __$$ReservationCalendarTabTargetListEventCopyWithImpl<
+          _$ReservationCalendarTabTargetListEvent>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initData,
+    required TResult Function(DateTime startTime, DateTime endTime) sectionList,
+    required TResult Function(DateTime targetDate) targetList,
+    required TResult Function() resetTargetList,
+  }) {
+    return targetList(targetDate);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initData,
+    TResult? Function(DateTime startTime, DateTime endTime)? sectionList,
+    TResult? Function(DateTime targetDate)? targetList,
+    TResult? Function()? resetTargetList,
+  }) {
+    return targetList?.call(targetDate);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initData,
+    TResult Function(DateTime startTime, DateTime endTime)? sectionList,
+    TResult Function(DateTime targetDate)? targetList,
+    TResult Function()? resetTargetList,
+    required TResult orElse(),
+  }) {
+    if (targetList != null) {
+      return targetList(targetDate);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ReservationCalendarTabInitDataEvent value)
+        initData,
+    required TResult Function(ReservationCalendarTabSectionListEvent value)
+        sectionList,
+    required TResult Function(ReservationCalendarTabTargetListEvent value)
+        targetList,
+    required TResult Function(ReservationCalendarTabResetTargetListEvent value)
+        resetTargetList,
+  }) {
+    return targetList(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ReservationCalendarTabInitDataEvent value)? initData,
+    TResult? Function(ReservationCalendarTabSectionListEvent value)?
+        sectionList,
+    TResult? Function(ReservationCalendarTabTargetListEvent value)? targetList,
+    TResult? Function(ReservationCalendarTabResetTargetListEvent value)?
+        resetTargetList,
+  }) {
+    return targetList?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ReservationCalendarTabInitDataEvent value)? initData,
+    TResult Function(ReservationCalendarTabSectionListEvent value)? sectionList,
+    TResult Function(ReservationCalendarTabTargetListEvent value)? targetList,
+    TResult Function(ReservationCalendarTabResetTargetListEvent value)?
+        resetTargetList,
+    required TResult orElse(),
+  }) {
+    if (targetList != null) {
+      return targetList(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ReservationCalendarTabTargetListEvent
+    implements ReservationCalendarTabEvent {
+  const factory ReservationCalendarTabTargetListEvent(
+          {required final DateTime targetDate}) =
+      _$ReservationCalendarTabTargetListEvent;
+
+  DateTime get targetDate;
+  @JsonKey(ignore: true)
+  _$$ReservationCalendarTabTargetListEventCopyWith<
+          _$ReservationCalendarTabTargetListEvent>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ReservationCalendarTabResetTargetListEventCopyWith<$Res> {
+  factory _$$ReservationCalendarTabResetTargetListEventCopyWith(
+          _$ReservationCalendarTabResetTargetListEvent value,
+          $Res Function(_$ReservationCalendarTabResetTargetListEvent) then) =
+      __$$ReservationCalendarTabResetTargetListEventCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$ReservationCalendarTabResetTargetListEventCopyWithImpl<$Res>
+    extends _$ReservationCalendarTabEventCopyWithImpl<$Res,
+        _$ReservationCalendarTabResetTargetListEvent>
+    implements _$$ReservationCalendarTabResetTargetListEventCopyWith<$Res> {
+  __$$ReservationCalendarTabResetTargetListEventCopyWithImpl(
+      _$ReservationCalendarTabResetTargetListEvent _value,
+      $Res Function(_$ReservationCalendarTabResetTargetListEvent) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$ReservationCalendarTabResetTargetListEvent
+    with DiagnosticableTreeMixin
+    implements ReservationCalendarTabResetTargetListEvent {
+  const _$ReservationCalendarTabResetTargetListEvent();
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'ReservationCalendarTabEvent.resetTargetList()';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty(
+        'type', 'ReservationCalendarTabEvent.resetTargetList'));
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReservationCalendarTabResetTargetListEvent);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initData,
+    required TResult Function(DateTime startTime, DateTime endTime) sectionList,
+    required TResult Function(DateTime targetDate) targetList,
+    required TResult Function() resetTargetList,
+  }) {
+    return resetTargetList();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initData,
+    TResult? Function(DateTime startTime, DateTime endTime)? sectionList,
+    TResult? Function(DateTime targetDate)? targetList,
+    TResult? Function()? resetTargetList,
+  }) {
+    return resetTargetList?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initData,
+    TResult Function(DateTime startTime, DateTime endTime)? sectionList,
+    TResult Function(DateTime targetDate)? targetList,
+    TResult Function()? resetTargetList,
+    required TResult orElse(),
+  }) {
+    if (resetTargetList != null) {
+      return resetTargetList();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ReservationCalendarTabInitDataEvent value)
+        initData,
+    required TResult Function(ReservationCalendarTabSectionListEvent value)
+        sectionList,
+    required TResult Function(ReservationCalendarTabTargetListEvent value)
+        targetList,
+    required TResult Function(ReservationCalendarTabResetTargetListEvent value)
+        resetTargetList,
+  }) {
+    return resetTargetList(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ReservationCalendarTabInitDataEvent value)? initData,
+    TResult? Function(ReservationCalendarTabSectionListEvent value)?
+        sectionList,
+    TResult? Function(ReservationCalendarTabTargetListEvent value)? targetList,
+    TResult? Function(ReservationCalendarTabResetTargetListEvent value)?
+        resetTargetList,
+  }) {
+    return resetTargetList?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ReservationCalendarTabInitDataEvent value)? initData,
+    TResult Function(ReservationCalendarTabSectionListEvent value)? sectionList,
+    TResult Function(ReservationCalendarTabTargetListEvent value)? targetList,
+    TResult Function(ReservationCalendarTabResetTargetListEvent value)?
+        resetTargetList,
+    required TResult orElse(),
+  }) {
+    if (resetTargetList != null) {
+      return resetTargetList(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ReservationCalendarTabResetTargetListEvent
+    implements ReservationCalendarTabEvent {
+  const factory ReservationCalendarTabResetTargetListEvent() =
+      _$ReservationCalendarTabResetTargetListEvent;
+}
+
+/// @nodoc
 mixin _$ReservationCalendarTabState {
   SectionListStatus get sectionListStatus => throw _privateConstructorUsedError;
+  TargetListStatus get targetListStatus => throw _privateConstructorUsedError;
   List<ReservationRangeSectionModel> get sectionList =>
       throw _privateConstructorUsedError;
+  List<ReservationTargetDateModel> get targetList =>
+      throw _privateConstructorUsedError;
   String? get sectionListErrorMsg => throw _privateConstructorUsedError;
+  String? get targetListErrorMsg => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $ReservationCalendarTabStateCopyWith<ReservationCalendarTabState>
@@ -391,8 +752,11 @@ abstract class $ReservationCalendarTabStateCopyWith<$Res> {
   @useResult
   $Res call(
       {SectionListStatus sectionListStatus,
+      TargetListStatus targetListStatus,
       List<ReservationRangeSectionModel> sectionList,
-      String? sectionListErrorMsg});
+      List<ReservationTargetDateModel> targetList,
+      String? sectionListErrorMsg,
+      String? targetListErrorMsg});
 }
 
 /// @nodoc
@@ -410,21 +774,36 @@ class _$ReservationCalendarTabStateCopyWithImpl<$Res,
   @override
   $Res call({
     Object? sectionListStatus = null,
+    Object? targetListStatus = null,
     Object? sectionList = null,
+    Object? targetList = null,
     Object? sectionListErrorMsg = freezed,
+    Object? targetListErrorMsg = freezed,
   }) {
     return _then(_value.copyWith(
       sectionListStatus: null == sectionListStatus
           ? _value.sectionListStatus
           : sectionListStatus // ignore: cast_nullable_to_non_nullable
               as SectionListStatus,
+      targetListStatus: null == targetListStatus
+          ? _value.targetListStatus
+          : targetListStatus // ignore: cast_nullable_to_non_nullable
+              as TargetListStatus,
       sectionList: null == sectionList
           ? _value.sectionList
           : sectionList // ignore: cast_nullable_to_non_nullable
               as List<ReservationRangeSectionModel>,
+      targetList: null == targetList
+          ? _value.targetList
+          : targetList // ignore: cast_nullable_to_non_nullable
+              as List<ReservationTargetDateModel>,
       sectionListErrorMsg: freezed == sectionListErrorMsg
           ? _value.sectionListErrorMsg
           : sectionListErrorMsg // ignore: cast_nullable_to_non_nullable
+              as String?,
+      targetListErrorMsg: freezed == targetListErrorMsg
+          ? _value.targetListErrorMsg
+          : targetListErrorMsg // ignore: cast_nullable_to_non_nullable
               as String?,
     ) as $Val);
   }
@@ -439,8 +818,11 @@ abstract class _$$InitialCopyWith<$Res>
   @useResult
   $Res call(
       {SectionListStatus sectionListStatus,
+      TargetListStatus targetListStatus,
       List<ReservationRangeSectionModel> sectionList,
-      String? sectionListErrorMsg});
+      List<ReservationTargetDateModel> targetList,
+      String? sectionListErrorMsg,
+      String? targetListErrorMsg});
 }
 
 /// @nodoc
@@ -454,21 +836,36 @@ class __$$InitialCopyWithImpl<$Res>
   @override
   $Res call({
     Object? sectionListStatus = null,
+    Object? targetListStatus = null,
     Object? sectionList = null,
+    Object? targetList = null,
     Object? sectionListErrorMsg = freezed,
+    Object? targetListErrorMsg = freezed,
   }) {
     return _then(_$Initial(
       sectionListStatus: null == sectionListStatus
           ? _value.sectionListStatus
           : sectionListStatus // ignore: cast_nullable_to_non_nullable
               as SectionListStatus,
+      targetListStatus: null == targetListStatus
+          ? _value.targetListStatus
+          : targetListStatus // ignore: cast_nullable_to_non_nullable
+              as TargetListStatus,
       sectionList: null == sectionList
           ? _value._sectionList
           : sectionList // ignore: cast_nullable_to_non_nullable
               as List<ReservationRangeSectionModel>,
+      targetList: null == targetList
+          ? _value._targetList
+          : targetList // ignore: cast_nullable_to_non_nullable
+              as List<ReservationTargetDateModel>,
       sectionListErrorMsg: freezed == sectionListErrorMsg
           ? _value.sectionListErrorMsg
           : sectionListErrorMsg // ignore: cast_nullable_to_non_nullable
+              as String?,
+      targetListErrorMsg: freezed == targetListErrorMsg
+          ? _value.targetListErrorMsg
+          : targetListErrorMsg // ignore: cast_nullable_to_non_nullable
               as String?,
     ));
   }
@@ -479,13 +876,20 @@ class __$$InitialCopyWithImpl<$Res>
 class _$Initial with DiagnosticableTreeMixin implements Initial {
   const _$Initial(
       {this.sectionListStatus = SectionListStatus.initial,
+      this.targetListStatus = TargetListStatus.initial,
       final List<ReservationRangeSectionModel> sectionList = const [],
-      this.sectionListErrorMsg = null})
-      : _sectionList = sectionList;
+      final List<ReservationTargetDateModel> targetList = const [],
+      this.sectionListErrorMsg = null,
+      this.targetListErrorMsg = null})
+      : _sectionList = sectionList,
+        _targetList = targetList;
 
   @override
   @JsonKey()
   final SectionListStatus sectionListStatus;
+  @override
+  @JsonKey()
+  final TargetListStatus targetListStatus;
   final List<ReservationRangeSectionModel> _sectionList;
   @override
   @JsonKey()
@@ -495,13 +899,25 @@ class _$Initial with DiagnosticableTreeMixin implements Initial {
     return EqualUnmodifiableListView(_sectionList);
   }
 
+  final List<ReservationTargetDateModel> _targetList;
+  @override
+  @JsonKey()
+  List<ReservationTargetDateModel> get targetList {
+    if (_targetList is EqualUnmodifiableListView) return _targetList;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_targetList);
+  }
+
   @override
   @JsonKey()
   final String? sectionListErrorMsg;
+  @override
+  @JsonKey()
+  final String? targetListErrorMsg;
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'ReservationCalendarTabState(sectionListStatus: $sectionListStatus, sectionList: $sectionList, sectionListErrorMsg: $sectionListErrorMsg)';
+    return 'ReservationCalendarTabState(sectionListStatus: $sectionListStatus, targetListStatus: $targetListStatus, sectionList: $sectionList, targetList: $targetList, sectionListErrorMsg: $sectionListErrorMsg, targetListErrorMsg: $targetListErrorMsg)';
   }
 
   @override
@@ -510,8 +926,11 @@ class _$Initial with DiagnosticableTreeMixin implements Initial {
     properties
       ..add(DiagnosticsProperty('type', 'ReservationCalendarTabState'))
       ..add(DiagnosticsProperty('sectionListStatus', sectionListStatus))
+      ..add(DiagnosticsProperty('targetListStatus', targetListStatus))
       ..add(DiagnosticsProperty('sectionList', sectionList))
-      ..add(DiagnosticsProperty('sectionListErrorMsg', sectionListErrorMsg));
+      ..add(DiagnosticsProperty('targetList', targetList))
+      ..add(DiagnosticsProperty('sectionListErrorMsg', sectionListErrorMsg))
+      ..add(DiagnosticsProperty('targetListErrorMsg', targetListErrorMsg));
   }
 
   @override
@@ -521,15 +940,27 @@ class _$Initial with DiagnosticableTreeMixin implements Initial {
             other is _$Initial &&
             (identical(other.sectionListStatus, sectionListStatus) ||
                 other.sectionListStatus == sectionListStatus) &&
+            (identical(other.targetListStatus, targetListStatus) ||
+                other.targetListStatus == targetListStatus) &&
             const DeepCollectionEquality()
                 .equals(other._sectionList, _sectionList) &&
+            const DeepCollectionEquality()
+                .equals(other._targetList, _targetList) &&
             (identical(other.sectionListErrorMsg, sectionListErrorMsg) ||
-                other.sectionListErrorMsg == sectionListErrorMsg));
+                other.sectionListErrorMsg == sectionListErrorMsg) &&
+            (identical(other.targetListErrorMsg, targetListErrorMsg) ||
+                other.targetListErrorMsg == targetListErrorMsg));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, sectionListStatus,
-      const DeepCollectionEquality().hash(_sectionList), sectionListErrorMsg);
+  int get hashCode => Object.hash(
+      runtimeType,
+      sectionListStatus,
+      targetListStatus,
+      const DeepCollectionEquality().hash(_sectionList),
+      const DeepCollectionEquality().hash(_targetList),
+      sectionListErrorMsg,
+      targetListErrorMsg);
 
   @JsonKey(ignore: true)
   @override
@@ -541,15 +972,24 @@ class _$Initial with DiagnosticableTreeMixin implements Initial {
 abstract class Initial implements ReservationCalendarTabState {
   const factory Initial(
       {final SectionListStatus sectionListStatus,
+      final TargetListStatus targetListStatus,
       final List<ReservationRangeSectionModel> sectionList,
-      final String? sectionListErrorMsg}) = _$Initial;
+      final List<ReservationTargetDateModel> targetList,
+      final String? sectionListErrorMsg,
+      final String? targetListErrorMsg}) = _$Initial;
 
   @override
   SectionListStatus get sectionListStatus;
   @override
+  TargetListStatus get targetListStatus;
+  @override
   List<ReservationRangeSectionModel> get sectionList;
   @override
+  List<ReservationTargetDateModel> get targetList;
+  @override
   String? get sectionListErrorMsg;
+  @override
+  String? get targetListErrorMsg;
   @override
   @JsonKey(ignore: true)
   _$$InitialCopyWith<_$Initial> get copyWith =>

--- a/lib/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_bloc.freezed.dart
+++ b/lib/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_bloc.freezed.dart
@@ -1,0 +1,557 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'reservation_calendar_tab_bloc.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$ReservationCalendarTabEvent {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initData,
+    required TResult Function(DateTime startTime, DateTime endTime) sectionList,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initData,
+    TResult? Function(DateTime startTime, DateTime endTime)? sectionList,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initData,
+    TResult Function(DateTime startTime, DateTime endTime)? sectionList,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ReservationCalendarTabInitDataEvent value)
+        initData,
+    required TResult Function(ReservationCalendarTabSectionListEvent value)
+        sectionList,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ReservationCalendarTabInitDataEvent value)? initData,
+    TResult? Function(ReservationCalendarTabSectionListEvent value)?
+        sectionList,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ReservationCalendarTabInitDataEvent value)? initData,
+    TResult Function(ReservationCalendarTabSectionListEvent value)? sectionList,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReservationCalendarTabEventCopyWith<$Res> {
+  factory $ReservationCalendarTabEventCopyWith(
+          ReservationCalendarTabEvent value,
+          $Res Function(ReservationCalendarTabEvent) then) =
+      _$ReservationCalendarTabEventCopyWithImpl<$Res,
+          ReservationCalendarTabEvent>;
+}
+
+/// @nodoc
+class _$ReservationCalendarTabEventCopyWithImpl<$Res,
+        $Val extends ReservationCalendarTabEvent>
+    implements $ReservationCalendarTabEventCopyWith<$Res> {
+  _$ReservationCalendarTabEventCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$ReservationCalendarTabInitDataEventCopyWith<$Res> {
+  factory _$$ReservationCalendarTabInitDataEventCopyWith(
+          _$ReservationCalendarTabInitDataEvent value,
+          $Res Function(_$ReservationCalendarTabInitDataEvent) then) =
+      __$$ReservationCalendarTabInitDataEventCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$ReservationCalendarTabInitDataEventCopyWithImpl<$Res>
+    extends _$ReservationCalendarTabEventCopyWithImpl<$Res,
+        _$ReservationCalendarTabInitDataEvent>
+    implements _$$ReservationCalendarTabInitDataEventCopyWith<$Res> {
+  __$$ReservationCalendarTabInitDataEventCopyWithImpl(
+      _$ReservationCalendarTabInitDataEvent _value,
+      $Res Function(_$ReservationCalendarTabInitDataEvent) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$ReservationCalendarTabInitDataEvent
+    with DiagnosticableTreeMixin
+    implements ReservationCalendarTabInitDataEvent {
+  const _$ReservationCalendarTabInitDataEvent();
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'ReservationCalendarTabEvent.initData()';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(
+        DiagnosticsProperty('type', 'ReservationCalendarTabEvent.initData'));
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReservationCalendarTabInitDataEvent);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initData,
+    required TResult Function(DateTime startTime, DateTime endTime) sectionList,
+  }) {
+    return initData();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initData,
+    TResult? Function(DateTime startTime, DateTime endTime)? sectionList,
+  }) {
+    return initData?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initData,
+    TResult Function(DateTime startTime, DateTime endTime)? sectionList,
+    required TResult orElse(),
+  }) {
+    if (initData != null) {
+      return initData();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ReservationCalendarTabInitDataEvent value)
+        initData,
+    required TResult Function(ReservationCalendarTabSectionListEvent value)
+        sectionList,
+  }) {
+    return initData(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ReservationCalendarTabInitDataEvent value)? initData,
+    TResult? Function(ReservationCalendarTabSectionListEvent value)?
+        sectionList,
+  }) {
+    return initData?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ReservationCalendarTabInitDataEvent value)? initData,
+    TResult Function(ReservationCalendarTabSectionListEvent value)? sectionList,
+    required TResult orElse(),
+  }) {
+    if (initData != null) {
+      return initData(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ReservationCalendarTabInitDataEvent
+    implements ReservationCalendarTabEvent {
+  const factory ReservationCalendarTabInitDataEvent() =
+      _$ReservationCalendarTabInitDataEvent;
+}
+
+/// @nodoc
+abstract class _$$ReservationCalendarTabSectionListEventCopyWith<$Res> {
+  factory _$$ReservationCalendarTabSectionListEventCopyWith(
+          _$ReservationCalendarTabSectionListEvent value,
+          $Res Function(_$ReservationCalendarTabSectionListEvent) then) =
+      __$$ReservationCalendarTabSectionListEventCopyWithImpl<$Res>;
+  @useResult
+  $Res call({DateTime startTime, DateTime endTime});
+}
+
+/// @nodoc
+class __$$ReservationCalendarTabSectionListEventCopyWithImpl<$Res>
+    extends _$ReservationCalendarTabEventCopyWithImpl<$Res,
+        _$ReservationCalendarTabSectionListEvent>
+    implements _$$ReservationCalendarTabSectionListEventCopyWith<$Res> {
+  __$$ReservationCalendarTabSectionListEventCopyWithImpl(
+      _$ReservationCalendarTabSectionListEvent _value,
+      $Res Function(_$ReservationCalendarTabSectionListEvent) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? startTime = null,
+    Object? endTime = null,
+  }) {
+    return _then(_$ReservationCalendarTabSectionListEvent(
+      startTime: null == startTime
+          ? _value.startTime
+          : startTime // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      endTime: null == endTime
+          ? _value.endTime
+          : endTime // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ReservationCalendarTabSectionListEvent
+    with DiagnosticableTreeMixin
+    implements ReservationCalendarTabSectionListEvent {
+  const _$ReservationCalendarTabSectionListEvent(
+      {required this.startTime, required this.endTime});
+
+  @override
+  final DateTime startTime;
+  @override
+  final DateTime endTime;
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'ReservationCalendarTabEvent.sectionList(startTime: $startTime, endTime: $endTime)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty(
+          'type', 'ReservationCalendarTabEvent.sectionList'))
+      ..add(DiagnosticsProperty('startTime', startTime))
+      ..add(DiagnosticsProperty('endTime', endTime));
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReservationCalendarTabSectionListEvent &&
+            (identical(other.startTime, startTime) ||
+                other.startTime == startTime) &&
+            (identical(other.endTime, endTime) || other.endTime == endTime));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, startTime, endTime);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ReservationCalendarTabSectionListEventCopyWith<
+          _$ReservationCalendarTabSectionListEvent>
+      get copyWith => __$$ReservationCalendarTabSectionListEventCopyWithImpl<
+          _$ReservationCalendarTabSectionListEvent>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initData,
+    required TResult Function(DateTime startTime, DateTime endTime) sectionList,
+  }) {
+    return sectionList(startTime, endTime);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initData,
+    TResult? Function(DateTime startTime, DateTime endTime)? sectionList,
+  }) {
+    return sectionList?.call(startTime, endTime);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initData,
+    TResult Function(DateTime startTime, DateTime endTime)? sectionList,
+    required TResult orElse(),
+  }) {
+    if (sectionList != null) {
+      return sectionList(startTime, endTime);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ReservationCalendarTabInitDataEvent value)
+        initData,
+    required TResult Function(ReservationCalendarTabSectionListEvent value)
+        sectionList,
+  }) {
+    return sectionList(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ReservationCalendarTabInitDataEvent value)? initData,
+    TResult? Function(ReservationCalendarTabSectionListEvent value)?
+        sectionList,
+  }) {
+    return sectionList?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ReservationCalendarTabInitDataEvent value)? initData,
+    TResult Function(ReservationCalendarTabSectionListEvent value)? sectionList,
+    required TResult orElse(),
+  }) {
+    if (sectionList != null) {
+      return sectionList(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ReservationCalendarTabSectionListEvent
+    implements ReservationCalendarTabEvent {
+  const factory ReservationCalendarTabSectionListEvent(
+          {required final DateTime startTime,
+          required final DateTime endTime}) =
+      _$ReservationCalendarTabSectionListEvent;
+
+  DateTime get startTime;
+  DateTime get endTime;
+  @JsonKey(ignore: true)
+  _$$ReservationCalendarTabSectionListEventCopyWith<
+          _$ReservationCalendarTabSectionListEvent>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$ReservationCalendarTabState {
+  SectionListStatus get sectionListStatus => throw _privateConstructorUsedError;
+  List<ReservationRangeSectionModel> get sectionList =>
+      throw _privateConstructorUsedError;
+  String? get sectionListErrorMsg => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ReservationCalendarTabStateCopyWith<ReservationCalendarTabState>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReservationCalendarTabStateCopyWith<$Res> {
+  factory $ReservationCalendarTabStateCopyWith(
+          ReservationCalendarTabState value,
+          $Res Function(ReservationCalendarTabState) then) =
+      _$ReservationCalendarTabStateCopyWithImpl<$Res,
+          ReservationCalendarTabState>;
+  @useResult
+  $Res call(
+      {SectionListStatus sectionListStatus,
+      List<ReservationRangeSectionModel> sectionList,
+      String? sectionListErrorMsg});
+}
+
+/// @nodoc
+class _$ReservationCalendarTabStateCopyWithImpl<$Res,
+        $Val extends ReservationCalendarTabState>
+    implements $ReservationCalendarTabStateCopyWith<$Res> {
+  _$ReservationCalendarTabStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? sectionListStatus = null,
+    Object? sectionList = null,
+    Object? sectionListErrorMsg = freezed,
+  }) {
+    return _then(_value.copyWith(
+      sectionListStatus: null == sectionListStatus
+          ? _value.sectionListStatus
+          : sectionListStatus // ignore: cast_nullable_to_non_nullable
+              as SectionListStatus,
+      sectionList: null == sectionList
+          ? _value.sectionList
+          : sectionList // ignore: cast_nullable_to_non_nullable
+              as List<ReservationRangeSectionModel>,
+      sectionListErrorMsg: freezed == sectionListErrorMsg
+          ? _value.sectionListErrorMsg
+          : sectionListErrorMsg // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InitialCopyWith<$Res>
+    implements $ReservationCalendarTabStateCopyWith<$Res> {
+  factory _$$InitialCopyWith(_$Initial value, $Res Function(_$Initial) then) =
+      __$$InitialCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {SectionListStatus sectionListStatus,
+      List<ReservationRangeSectionModel> sectionList,
+      String? sectionListErrorMsg});
+}
+
+/// @nodoc
+class __$$InitialCopyWithImpl<$Res>
+    extends _$ReservationCalendarTabStateCopyWithImpl<$Res, _$Initial>
+    implements _$$InitialCopyWith<$Res> {
+  __$$InitialCopyWithImpl(_$Initial _value, $Res Function(_$Initial) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? sectionListStatus = null,
+    Object? sectionList = null,
+    Object? sectionListErrorMsg = freezed,
+  }) {
+    return _then(_$Initial(
+      sectionListStatus: null == sectionListStatus
+          ? _value.sectionListStatus
+          : sectionListStatus // ignore: cast_nullable_to_non_nullable
+              as SectionListStatus,
+      sectionList: null == sectionList
+          ? _value._sectionList
+          : sectionList // ignore: cast_nullable_to_non_nullable
+              as List<ReservationRangeSectionModel>,
+      sectionListErrorMsg: freezed == sectionListErrorMsg
+          ? _value.sectionListErrorMsg
+          : sectionListErrorMsg // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$Initial with DiagnosticableTreeMixin implements Initial {
+  const _$Initial(
+      {this.sectionListStatus = SectionListStatus.initial,
+      final List<ReservationRangeSectionModel> sectionList = const [],
+      this.sectionListErrorMsg = null})
+      : _sectionList = sectionList;
+
+  @override
+  @JsonKey()
+  final SectionListStatus sectionListStatus;
+  final List<ReservationRangeSectionModel> _sectionList;
+  @override
+  @JsonKey()
+  List<ReservationRangeSectionModel> get sectionList {
+    if (_sectionList is EqualUnmodifiableListView) return _sectionList;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_sectionList);
+  }
+
+  @override
+  @JsonKey()
+  final String? sectionListErrorMsg;
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'ReservationCalendarTabState(sectionListStatus: $sectionListStatus, sectionList: $sectionList, sectionListErrorMsg: $sectionListErrorMsg)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'ReservationCalendarTabState'))
+      ..add(DiagnosticsProperty('sectionListStatus', sectionListStatus))
+      ..add(DiagnosticsProperty('sectionList', sectionList))
+      ..add(DiagnosticsProperty('sectionListErrorMsg', sectionListErrorMsg));
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$Initial &&
+            (identical(other.sectionListStatus, sectionListStatus) ||
+                other.sectionListStatus == sectionListStatus) &&
+            const DeepCollectionEquality()
+                .equals(other._sectionList, _sectionList) &&
+            (identical(other.sectionListErrorMsg, sectionListErrorMsg) ||
+                other.sectionListErrorMsg == sectionListErrorMsg));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, sectionListStatus,
+      const DeepCollectionEquality().hash(_sectionList), sectionListErrorMsg);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InitialCopyWith<_$Initial> get copyWith =>
+      __$$InitialCopyWithImpl<_$Initial>(this, _$identity);
+}
+
+abstract class Initial implements ReservationCalendarTabState {
+  const factory Initial(
+      {final SectionListStatus sectionListStatus,
+      final List<ReservationRangeSectionModel> sectionList,
+      final String? sectionListErrorMsg}) = _$Initial;
+
+  @override
+  SectionListStatus get sectionListStatus;
+  @override
+  List<ReservationRangeSectionModel> get sectionList;
+  @override
+  String? get sectionListErrorMsg;
+  @override
+  @JsonKey(ignore: true)
+  _$$InitialCopyWith<_$Initial> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_event.dart
+++ b/lib/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_event.dart
@@ -9,4 +9,10 @@ class ReservationCalendarTabEvent with _$ReservationCalendarTabEvent {
     required DateTime startTime,
     required DateTime endTime,
   }) = ReservationCalendarTabSectionListEvent;
+
+  const factory ReservationCalendarTabEvent.targetList({
+    required DateTime targetDate,
+  }) = ReservationCalendarTabTargetListEvent;
+
+  const factory ReservationCalendarTabEvent.resetTargetList() = ReservationCalendarTabResetTargetListEvent;
 }

--- a/lib/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_event.dart
+++ b/lib/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_event.dart
@@ -1,0 +1,12 @@
+part of 'reservation_calendar_tab_bloc.dart';
+
+@freezed
+class ReservationCalendarTabEvent with _$ReservationCalendarTabEvent {
+  const factory ReservationCalendarTabEvent.initData() =
+      ReservationCalendarTabInitDataEvent;
+
+  const factory ReservationCalendarTabEvent.sectionList({
+    required DateTime startTime,
+    required DateTime endTime,
+  }) = ReservationCalendarTabSectionListEvent;
+}

--- a/lib/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_state.dart
+++ b/lib/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_state.dart
@@ -7,11 +7,21 @@ enum SectionListStatus {
   error,
 }
 
+enum TargetListStatus {
+  initial,
+  loading,
+  success,
+  error,
+}
+
 @freezed
 class ReservationCalendarTabState with _$ReservationCalendarTabState {
   const factory ReservationCalendarTabState({
     @Default(SectionListStatus.initial) SectionListStatus sectionListStatus,
+    @Default(TargetListStatus.initial) TargetListStatus targetListStatus,
     @Default([]) List<ReservationRangeSectionModel> sectionList,
+    @Default([]) List<ReservationTargetDateModel> targetList,
     @Default(null) String? sectionListErrorMsg,
+    @Default(null) String? targetListErrorMsg,
   }) = Initial;
 }

--- a/lib/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_state.dart
+++ b/lib/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_state.dart
@@ -1,0 +1,17 @@
+part of 'reservation_calendar_tab_bloc.dart';
+
+enum SectionListStatus {
+  initial,
+  loading,
+  success,
+  error,
+}
+
+@freezed
+class ReservationCalendarTabState with _$ReservationCalendarTabState {
+  const factory ReservationCalendarTabState({
+    @Default(SectionListStatus.initial) SectionListStatus sectionListStatus,
+    @Default([]) List<ReservationRangeSectionModel> sectionList,
+    @Default(null) String? sectionListErrorMsg,
+  }) = Initial;
+}

--- a/lib/presentation/views/main/tabs/search/calendar/reservation_calendar_tab_screen.dart
+++ b/lib/presentation/views/main/tabs/search/calendar/reservation_calendar_tab_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reservation_app/domain/model/reservation/enum/part_time.dart';
 import 'package:reservation_app/domain/model/reservation/reservation_range_section_model.dart';
 import 'package:reservation_app/presentation/utils/color_constants.dart';
 import 'package:reservation_app/presentation/utils/dialog_utils.dart';
@@ -168,6 +169,53 @@ class _ReservationCalendarTabScreenState
 
                 return events;
               },
+              calendarBuilders: CalendarBuilders(
+                markerBuilder:
+                    (context, day, List<ReservationRangeSectionModel> events) {
+                  if (events.isEmpty) return SizedBox();
+
+                  return ListView.builder(
+                    shrinkWrap: true,
+                    scrollDirection: Axis.horizontal,
+                    itemCount: events.length,
+                    itemBuilder: (context, index) {
+                      final item = events[index];
+                      final eachColor = item.partTime == PartTime.partA
+                          ? ColorsConstants.partTimeA
+                          : item.partTime == PartTime.partB
+                              ? ColorsConstants.partTimeB
+                              : item.partTime == PartTime.partC
+                                  ? ColorsConstants.partTimeC
+                                  : ColorsConstants.background;
+
+                      return Container(
+                        margin: const EdgeInsets.only(top: 35),
+                        padding: const EdgeInsets.all(1),
+                        child: Container(
+                          height: 14,
+                          // for vertical axis
+                          width: 14,
+                          // for horizontal axis
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: eachColor,
+                          ),
+                          child: Center(
+                            child: Text(
+                              "${events[index].list.length}",
+                              style: TextStyle(
+                                color: ColorsConstants.background,
+                                fontSize: 10,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
               startingDayOfWeek: StartingDayOfWeek.monday,
               // 주의 첫 번째 날을 월요일로 설정
               calendarStyle: CalendarStyle(
@@ -201,7 +249,7 @@ class _ReservationCalendarTabScreenState
                   fontSize: 16.0,
                 ),
                 todayDecoration: const BoxDecoration(
-                  color: ColorsConstants.calendarCurrentColor,
+                  color: ColorsConstants.currentDate,
                   shape: BoxShape.circle,
                 ),
                 selectedTextStyle: const TextStyle(
@@ -209,7 +257,7 @@ class _ReservationCalendarTabScreenState
                   fontSize: 16.0,
                 ),
                 selectedDecoration: const BoxDecoration(
-                  color: ColorsConstants.calendarRangeColor,
+                  color: ColorsConstants.selectedDate,
                   shape: BoxShape.circle,
                 ),
                 holidayTextStyle: const TextStyle(

--- a/lib/presentation/views/main/tabs/search/calendar/reservation_calendar_tab_screen.dart
+++ b/lib/presentation/views/main/tabs/search/calendar/reservation_calendar_tab_screen.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:grouped_list/grouped_list.dart';
-import 'package:reservation_app/domain/model/reservation/enum/part_time.dart';
+import 'package:lottie/lottie.dart';
+import 'package:pull_to_refresh/pull_to_refresh.dart';
 import 'package:reservation_app/domain/model/reservation/reservation_range_section_model.dart';
 import 'package:reservation_app/presentation/utils/color_constants.dart';
 import 'package:reservation_app/presentation/utils/date_time_utils.dart';
 import 'package:reservation_app/presentation/utils/dialog_utils.dart';
 import 'package:reservation_app/presentation/utils/snack_bar_utils.dart';
+import 'package:reservation_app/presentation/views/common/empty_widget.dart';
+import 'package:reservation_app/presentation/views/common/network_loading_widget.dart';
 import 'package:reservation_app/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/search/calendar/utils/calendar_utils.dart';
 import 'package:reservation_app/presentation/views/reservation/utils/reservation_utils.dart';
@@ -23,12 +26,15 @@ class ReservationCalendarTabScreen extends StatefulWidget {
 class _ReservationCalendarTabScreenState
     extends State<ReservationCalendarTabScreen> {
   late final ReservationCalendarTabBloc _reservationCalendarTabBloc;
+  late final RefreshController _refreshController;
+
   ValueNotifier<List<ReservationRangeSectionModel>> _selectedEvents =
       ValueNotifier([]);
 
   CalendarFormat _calendarFormat = CalendarFormat.month;
   RangeSelectionMode _rangeSelectionMode = RangeSelectionMode.toggledOff;
   DateTime _focusedDay = DateTime.now();
+  bool _isDetailShow = false;
 
   DateTime? _selectedDay;
   DateTime? _rangeStart;
@@ -40,10 +46,18 @@ class _ReservationCalendarTabScreenState
     _reservationCalendarTabBloc = BlocProvider.of<ReservationCalendarTabBloc>(
       context,
     );
+    _refreshController = RefreshController(initialRefresh: false);
+
     _selectedDay = _focusedDay;
 
     // 데이터 호출
     _reservationCalendarTabBloc.add(ReservationCalendarTabInitDataEvent());
+  }
+
+  @override
+  void dispose() {
+    _refreshController.dispose();
+    super.dispose();
   }
 
   List<ReservationRangeSectionModel> _getEventsForDay(
@@ -121,6 +135,27 @@ class _ReservationCalendarTabScreenState
     }
   }
 
+  void _toggleIsShowDetail() {
+    setState(() {
+      _isDetailShow = !_isDetailShow;
+    });
+  }
+
+  void _onRefresh() async {
+    await Future.delayed(Duration(milliseconds: 1000));
+    setState(() {
+      _focusedDay = DateTime.now();
+      _selectedDay = _focusedDay;
+      _rangeStart = null;
+      _rangeEnd = null;
+      _calendarFormat = CalendarFormat.month;
+      _rangeSelectionMode = RangeSelectionMode.toggledOff;
+      _isDetailShow = false;
+    });
+    _reservationCalendarTabBloc.add(ReservationCalendarTabInitDataEvent());
+    _refreshController.refreshCompleted();
+  }
+
   @override
   Widget build(BuildContext context) {
     return BlocConsumer<ReservationCalendarTabBloc,
@@ -149,224 +184,315 @@ class _ReservationCalendarTabScreenState
         return previous != current;
       },
       builder: (context, state) {
-        return Column(
-          children: [
-            TableCalendar(
-              locale: 'ko_KR',
-              firstDay: DateTime(DateTime.now().year),
-              lastDay: DateTime(DateTime.now().year + 1),
-              focusedDay: _focusedDay,
-              selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
-              rangeStartDay: _rangeStart,
-              rangeEndDay: _rangeEnd,
-              calendarFormat: _calendarFormat,
-              rangeSelectionMode: _rangeSelectionMode,
-              eventLoader: (date) {
-                final events = <ReservationRangeSectionModel>[];
+        return Scaffold(
+          body: SmartRefresher(
+            controller: _refreshController,
+            onRefresh: _onRefresh,
+            enablePullDown: true,
+            enablePullUp: false,
+            header: WaterDropHeader(
+              completeDuration: Duration(milliseconds: 1000),
+              refresh: NetworkLoadingWidget(),
+              complete: Lottie.asset(
+                'assets/lottie/success_animation.json',
+                animate: true,
+                width: 100,
+                height: 100,
+                repeat: false,
+              ),
+            ),
+            child: Column(
+              children: [
+                TableCalendar(
+                  locale: 'ko_KR',
+                  firstDay: DateTime(DateTime.now().year),
+                  lastDay: DateTime(DateTime.now().year + 1),
+                  focusedDay: _focusedDay,
+                  selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
+                  rangeStartDay: _rangeStart,
+                  rangeEndDay: _rangeEnd,
+                  calendarFormat: _calendarFormat,
+                  rangeSelectionMode: _rangeSelectionMode,
+                  eventLoader: (date) {
+                    final events = <ReservationRangeSectionModel>[];
 
-                for (final section in state.sectionList) {
-                  if (isSameDay(DateTime.parse(section.sectionTitle), date)) {
-                    events.add(section);
-                  }
-                }
+                    for (final section in state.sectionList) {
+                      if (isSameDay(DateTime.parse(section.sectionTitle), date)) {
+                        events.add(section);
+                      }
+                    }
 
-                return events;
-              },
-              calendarBuilders: CalendarBuilders(
-                markerBuilder:
-                    (context, day, List<ReservationRangeSectionModel> events) {
-                  if (events.isEmpty) return SizedBox();
+                    return events;
+                  },
+                  calendarBuilders: CalendarBuilders(
+                    markerBuilder: (context, day,
+                        List<ReservationRangeSectionModel> events) {
+                      if (events.isEmpty) return SizedBox();
 
-                  return ListView.builder(
-                    shrinkWrap: true,
-                    scrollDirection: Axis.horizontal,
-                    itemCount: events.length,
-                    itemBuilder: (context, index) {
-                      final item = events[index];
-                      final eachColor = item.partTime == PartTime.partA
-                          ? ColorsConstants.partTimeA
-                          : item.partTime == PartTime.partB
-                              ? ColorsConstants.partTimeB
-                              : item.partTime == PartTime.partC
-                                  ? ColorsConstants.partTimeC
-                                  : ColorsConstants.background;
+                      return ListView.builder(
+                        shrinkWrap: true,
+                        scrollDirection: Axis.horizontal,
+                        itemCount: events.length,
+                        itemBuilder: (context, index) {
+                          final item = events[index];
 
-                      return Container(
-                        margin: const EdgeInsets.only(top: 35),
-                        padding: const EdgeInsets.all(1),
-                        child: Container(
-                          height: 14,
-                          // for vertical axis
-                          width: 14,
-                          // for horizontal axis
-                          decoration: BoxDecoration(
-                            shape: BoxShape.circle,
-                            color: eachColor,
-                          ),
-                          child: Center(
-                            child: Text(
-                              "${events[index].list.length}",
-                              style: TextStyle(
-                                color: ColorsConstants.background,
-                                fontSize: 10,
-                                fontWeight: FontWeight.bold,
+                          return Container(
+                            margin: const EdgeInsets.only(top: 35),
+                            padding: const EdgeInsets.all(1),
+                            child: Container(
+                              height: 14,
+                              // for vertical axis
+                              width: 14,
+                              // for horizontal axis
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: ColorsConstants.getParTimeColor(
+                                  item.partTime,
+                                ),
                               ),
+                              child: Center(
+                                child: Text(
+                                  "${events[index].list.length}",
+                                  style: TextStyle(
+                                    color: ColorsConstants.background,
+                                    fontSize: 10,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          );
+                        },
+                      );
+                    },
+                  ),
+                  startingDayOfWeek: StartingDayOfWeek.monday,
+                  // 주의 첫 번째 날을 월요일로 설정
+                  calendarStyle: CalendarStyle(
+                    outsideDaysVisible: false,
+                    // 달력에서 현재 월 이외의 날짜 숨김, false 👉 숨김
+                    canMarkersOverflow: false,
+                    markerMargin: const EdgeInsets.symmetric(horizontal: 0.3),
+                    markerDecoration: const BoxDecoration(
+                      color: ColorsConstants.primary,
+                      shape: BoxShape.circle,
+                    ),
+                    rangeHighlightColor: ColorsConstants.calendarSideColor,
+                    rangeStartTextStyle: const TextStyle(
+                      color: ColorsConstants.background,
+                      fontSize: 16.0,
+                    ),
+                    rangeStartDecoration: const BoxDecoration(
+                      color: ColorsConstants.calendarPickerColor,
+                      shape: BoxShape.circle,
+                    ),
+                    rangeEndTextStyle: const TextStyle(
+                      color: ColorsConstants.background,
+                      fontSize: 16.0,
+                    ),
+                    rangeEndDecoration: const BoxDecoration(
+                      color: ColorsConstants.calendarPickerColor,
+                      shape: BoxShape.circle,
+                    ),
+                    todayTextStyle: const TextStyle(
+                      color: ColorsConstants.background,
+                      fontSize: 16.0,
+                    ),
+                    todayDecoration: const BoxDecoration(
+                      color: ColorsConstants.currentDate,
+                      shape: BoxShape.circle,
+                    ),
+                    selectedTextStyle: const TextStyle(
+                      color: ColorsConstants.background,
+                      fontSize: 16.0,
+                    ),
+                    selectedDecoration: const BoxDecoration(
+                      color: ColorsConstants.selectedDate,
+                      shape: BoxShape.circle,
+                    ),
+                    holidayTextStyle: const TextStyle(
+                      color: ColorsConstants.primary,
+                    ),
+                    holidayDecoration: const BoxDecoration(
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                  onDaySelected: (selectedDay, focusedDay) {
+                    if (selectedDay.weekday == 2) {
+                      SnackBarUtils.showCustomSnackBar(context, "매주 화요일은 휴무입니다.");
+                      return;
+                    }
+
+                    _onDaySelected(selectedDay, focusedDay, state.sectionList);
+                  },
+                  onRangeSelected: (start, end, focusedDay) {
+                    // 범위 날짜가 선택되었을 때 호출되는 콜백 함수
+                    _onRangeSelected(start, end, focusedDay, state.sectionList);
+                  },
+                  // 범위가 선택되었을 때 호출되는 콜백 함수
+                  onFormatChanged: (format) {
+                    if (_calendarFormat != format) {
+                      setState(() {
+                        _calendarFormat = format; // 달력 형식 변경 시 상태 업데이트
+                      });
+                    }
+                  },
+                  // 현재 페이지가 변경될 때 현재 포커스 날짜 업데이트
+                  onPageChanged: (focusedDay) {
+                    setState(() {
+                      _focusedDay = focusedDay;
+                      _reservationCalendarTabBloc.add(
+                        ReservationCalendarTabSectionListEvent(
+                          startTime: DateTime(
+                            focusedDay.year,
+                            focusedDay.month,
+                            1,
+                          ),
+                          endTime: DateTime(
+                            focusedDay.year,
+                            focusedDay.month + 1,
+                            1,
+                          ),
+                        ),
+                      );
+                    });
+                  },
+                  holidayPredicate: (day) {
+                    // 매주 화요일 쉬는 날
+                    return day.weekday == 2;
+                  },
+                  headerStyle: HeaderStyle(
+                    titleCentered: true,
+                    formatButtonVisible: false,
+                    titleTextStyle: const TextStyle(
+                      fontSize: 20.0,
+                      color: ColorsConstants.strokeColor,
+                      fontWeight: FontWeight.bold,
+                    ),
+                    headerPadding: const EdgeInsets.symmetric(vertical: 4.0),
+                    leftChevronIcon: const Icon(
+                      Icons.arrow_left_rounded,
+                      size: 40.0,
+                      color: ColorsConstants.strokeColor,
+                    ),
+                    rightChevronIcon: const Icon(
+                      Icons.arrow_right_rounded,
+                      size: 40.0,
+                      color: ColorsConstants.strokeColor,
+                    ),
+                  ),
+                ),
+                Container(
+                  margin: EdgeInsets.only(
+                    top: 10,
+                    bottom: 10,
+                  ),
+                  height: 10.0,
+                  color: ColorsConstants.settingDivider,
+                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    TextButton(
+                      onPressed: () {
+                        if (_isDetailShow) {
+                          _toggleIsShowDetail();
+                        }
+                      },
+                      child: Text(
+                        "요약 보기",
+                        style: TextStyle(
+                          fontSize: 14,
+                          color: !_isDetailShow
+                              ? ColorsConstants.boldColor
+                              : ColorsConstants.textHint,
+                          fontWeight: !_isDetailShow
+                              ? FontWeight.bold
+                              : FontWeight.normal,
+                        ),
+                      ),
+                    ),
+                    Text(
+                      "|",
+                      style: TextStyle(color: ColorsConstants.divider),
+                    ),
+                    TextButton(
+                      onPressed: () {
+                        if (!_isDetailShow) {
+                          _toggleIsShowDetail();
+                        }
+                      },
+                      child: Text(
+                        "상세 보기",
+                        style: TextStyle(
+                          fontSize: 14,
+                          color: _isDetailShow
+                              ? ColorsConstants.boldColor
+                              : ColorsConstants.textHint,
+                          fontWeight:
+                              _isDetailShow ? FontWeight.bold : FontWeight.normal,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                Expanded(
+                  child:
+                      ValueListenableBuilder<List<ReservationRangeSectionModel>>(
+                    valueListenable: _selectedEvents,
+                    builder: (context, value, _) {
+                      if (value.isEmpty) {
+                        return EmptyWidget(
+                          message: "예약이 없어요..",
+                        );
+                      }
+
+                      return GroupedListView<ReservationRangeSectionModel,
+                          String>(
+                        elements: value,
+                        groupBy: (element) =>
+                            "${DateTimeUtils.dateTimeToString(pattern: "yy-MM-dd", date: DateTime.parse(element.sectionTitle))} ${ReservationUtils.partTimeToString(partTime: element.partTime.index)}",
+                        groupSeparatorBuilder: (groupByValue) => Container(
+                          margin: EdgeInsets.only(
+                            left: 15,
+                            right: 15,
+                            top: 10,
+                            bottom: 5,
+                          ),
+                          child: Text(
+                            groupByValue,
+                            style: TextStyle(
+                              color: ColorsConstants.strokeColor,
+                              fontSize: 16,
+                              fontWeight: FontWeight.bold,
                             ),
                           ),
                         ),
+                        indexedItemBuilder: (context, element, index) {
+                          return Container(
+                            margin: EdgeInsets.only(
+                              left: 10,
+                              right: 10,
+                              top: index == 0 ? 10 : 5,
+                              bottom: index == value.length - 1 ? 10 : 5,
+                            ),
+                            decoration: BoxDecoration(
+                              border: Border.all(),
+                              borderRadius: BorderRadius.circular(12.0),
+                            ),
+                            child: ListTile(
+                              onTap: () => print('${value[index]}'),
+                              title: Text('${value[index]}'),
+                            ),
+                          );
+                        },
                       );
                     },
-                  );
-                },
-              ),
-              startingDayOfWeek: StartingDayOfWeek.monday,
-              // 주의 첫 번째 날을 월요일로 설정
-              calendarStyle: CalendarStyle(
-                outsideDaysVisible: false,
-                // 달력에서 현재 월 이외의 날짜 숨김, false 👉 숨김
-                canMarkersOverflow: false,
-                markerMargin: const EdgeInsets.symmetric(horizontal: 0.3),
-                markerDecoration: const BoxDecoration(
-                  color: ColorsConstants.primary,
-                  shape: BoxShape.circle,
+                  ),
                 ),
-                rangeHighlightColor: ColorsConstants.calendarSideColor,
-                rangeStartTextStyle: const TextStyle(
-                  color: ColorsConstants.background,
-                  fontSize: 16.0,
-                ),
-                rangeStartDecoration: const BoxDecoration(
-                  color: ColorsConstants.calendarPickerColor,
-                  shape: BoxShape.circle,
-                ),
-                rangeEndTextStyle: const TextStyle(
-                  color: ColorsConstants.background,
-                  fontSize: 16.0,
-                ),
-                rangeEndDecoration: const BoxDecoration(
-                  color: ColorsConstants.calendarPickerColor,
-                  shape: BoxShape.circle,
-                ),
-                todayTextStyle: const TextStyle(
-                  color: ColorsConstants.background,
-                  fontSize: 16.0,
-                ),
-                todayDecoration: const BoxDecoration(
-                  color: ColorsConstants.currentDate,
-                  shape: BoxShape.circle,
-                ),
-                selectedTextStyle: const TextStyle(
-                  color: ColorsConstants.background,
-                  fontSize: 16.0,
-                ),
-                selectedDecoration: const BoxDecoration(
-                  color: ColorsConstants.selectedDate,
-                  shape: BoxShape.circle,
-                ),
-                holidayTextStyle: const TextStyle(
-                  color: ColorsConstants.primary,
-                ),
-                holidayDecoration: const BoxDecoration(
-                  shape: BoxShape.circle,
-                ),
-              ),
-              onDaySelected: (selectedDay, focusedDay) {
-                if (selectedDay.weekday == 2) {
-                  SnackBarUtils.showCustomSnackBar(context, "매주 화요일은 휴무입니다.");
-                  return;
-                }
-
-                _onDaySelected(selectedDay, focusedDay, state.sectionList);
-              },
-              onRangeSelected: (start, end, focusedDay) {
-                // 범위 날짜가 선택되었을 때 호출되는 콜백 함수
-                _onRangeSelected(start, end, focusedDay, state.sectionList);
-              },
-              // 범위가 선택되었을 때 호출되는 콜백 함수
-              onFormatChanged: (format) {
-                if (_calendarFormat != format) {
-                  setState(() {
-                    _calendarFormat = format; // 달력 형식 변경 시 상태 업데이트
-                  });
-                }
-              },
-              // 현재 페이지가 변경될 때 현재 포커스 날짜 업데이트
-              onPageChanged: (focusedDay) {
-                setState(() {
-                  _focusedDay = focusedDay;
-                  _reservationCalendarTabBloc.add(
-                    ReservationCalendarTabSectionListEvent(
-                      startTime: DateTime(
-                        focusedDay.year,
-                        focusedDay.month,
-                        1,
-                      ),
-                      endTime: DateTime(
-                        focusedDay.year,
-                        focusedDay.month + 1,
-                        1,
-                      ),
-                    ),
-                  );
-                });
-              },
-              holidayPredicate: (day) {
-                // 매주 화요일 쉬는 날
-                return day.weekday == 2;
-              },
-              headerStyle: HeaderStyle(
-                titleCentered: true,
-                formatButtonVisible: false,
-                titleTextStyle: const TextStyle(
-                  fontSize: 20.0,
-                  color: ColorsConstants.strokeColor,
-                  fontWeight: FontWeight.bold,
-                ),
-                headerPadding: const EdgeInsets.symmetric(vertical: 4.0),
-                leftChevronIcon: const Icon(
-                  Icons.arrow_left_rounded,
-                  size: 40.0,
-                  color: ColorsConstants.strokeColor,
-                ),
-                rightChevronIcon: const Icon(
-                  Icons.arrow_right_rounded,
-                  size: 40.0,
-                  color: ColorsConstants.strokeColor,
-                ),
-              ),
+              ],
             ),
-            const SizedBox(height: 10.0),
-            Expanded(
-              child: ValueListenableBuilder<List<ReservationRangeSectionModel>>(
-                valueListenable: _selectedEvents,
-                builder: (context, value, _) {
-                  return GroupedListView<ReservationRangeSectionModel, String>(
-                    elements: value,
-                    groupBy: (element) => _rangeSelectionMode == RangeSelectionMode.toggledOff ? "${ReservationUtils.partTimeToString(partTime: element.partTime.index)}" : "${DateTimeUtils.dateTimeToString(pattern: "yy-MM-dd", date: DateTime.parse(element.sectionTitle))} ${ReservationUtils.partTimeToString(partTime: element.partTime.index)}",
-                    groupSeparatorBuilder: (groupByValue) => Text(groupByValue),
-                    indexedItemBuilder: (context, element, index) {
-                      return Container(
-                        margin: EdgeInsets.only(
-                          left: 10,
-                          right: 10,
-                          top: index == 0 ? 10 : 5,
-                          bottom: index == value.length - 1 ? 10 : 5,
-                        ),
-                        decoration: BoxDecoration(
-                          border: Border.all(),
-                          borderRadius: BorderRadius.circular(12.0),
-                        ),
-                        child: ListTile(
-                          onTap: () => print('${value[index]}'),
-                          title: Text('${value[index]}'),
-                        ),
-                      );
-                    },
-                  );
-                },
-              ),
-            ),
-          ],
+          ),
         );
       },
     );

--- a/lib/presentation/views/main/tabs/search/calendar/reservation_calendar_tab_screen.dart
+++ b/lib/presentation/views/main/tabs/search/calendar/reservation_calendar_tab_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reservation_app/presentation/utils/color_constants.dart';
+import 'package:reservation_app/presentation/utils/dialog_utils.dart';
 import 'package:reservation_app/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/search/calendar/utils/calendar_utils.dart';
 import 'package:table_calendar/table_calendar.dart';
@@ -84,15 +85,30 @@ class _ReservationCalendarTabScreenState
     }
   }
 
+  void _popBackStack() {
+    if (Navigator.of(context).canPop()) {
+      Navigator.of(context).pop();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return BlocConsumer<ReservationCalendarTabBloc,
         ReservationCalendarTabState>(
       bloc: _reservationCalendarTabBloc,
       listenWhen: (previous, current) {
-        return previous != current;
+        return previous != current &&
+            previous.sectionListStatus != current.sectionListStatus;
       },
-      listener: (context, state) {},
+      listener: (context, state) {
+        if (state.sectionListStatus == SectionListStatus.loading) {
+          DialogUtils.showLoadingDialog(context);
+        } else if (state.sectionListStatus == SectionListStatus.success) {
+          _popBackStack();
+        } else if (state.sectionListStatus == SectionListStatus.error) {
+          _popBackStack();
+        }
+      },
       buildWhen: (previous, current) {
         return previous != current;
       },

--- a/lib/presentation/views/main/tabs/search/calendar/reservation_calendar_tab_screen.dart
+++ b/lib/presentation/views/main/tabs/search/calendar/reservation_calendar_tab_screen.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:grouped_list/grouped_list.dart';
 import 'package:reservation_app/domain/model/reservation/enum/part_time.dart';
 import 'package:reservation_app/domain/model/reservation/reservation_range_section_model.dart';
 import 'package:reservation_app/presentation/utils/color_constants.dart';
+import 'package:reservation_app/presentation/utils/date_time_utils.dart';
 import 'package:reservation_app/presentation/utils/dialog_utils.dart';
 import 'package:reservation_app/presentation/utils/snack_bar_utils.dart';
 import 'package:reservation_app/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/search/calendar/utils/calendar_utils.dart';
+import 'package:reservation_app/presentation/views/reservation/utils/reservation_utils.dart';
 import 'package:table_calendar/table_calendar.dart';
 
 class ReservationCalendarTabScreen extends StatefulWidget {
@@ -337,9 +340,11 @@ class _ReservationCalendarTabScreenState
               child: ValueListenableBuilder<List<ReservationRangeSectionModel>>(
                 valueListenable: _selectedEvents,
                 builder: (context, value, _) {
-                  return ListView.builder(
-                    itemCount: value.length,
-                    itemBuilder: (context, index) {
+                  return GroupedListView<ReservationRangeSectionModel, String>(
+                    elements: value,
+                    groupBy: (element) => _rangeSelectionMode == RangeSelectionMode.toggledOff ? "${ReservationUtils.partTimeToString(partTime: element.partTime.index)}" : "${DateTimeUtils.dateTimeToString(pattern: "yy-MM-dd", date: DateTime.parse(element.sectionTitle))} ${ReservationUtils.partTimeToString(partTime: element.partTime.index)}",
+                    groupSeparatorBuilder: (groupByValue) => Text(groupByValue),
+                    indexedItemBuilder: (context, element, index) {
                       return Container(
                         margin: EdgeInsets.only(
                           left: 10,

--- a/lib/presentation/views/main/tabs/search/calendar/reservation_calendar_tab_screen.dart
+++ b/lib/presentation/views/main/tabs/search/calendar/reservation_calendar_tab_screen.dart
@@ -1,5 +1,6 @@
 
 import 'package:flutter/material.dart';
+import 'package:table_calendar/table_calendar.dart';
 
 class ReservationCalendarTabScreen extends StatefulWidget {
   const ReservationCalendarTabScreen({Key? key}) : super(key: key);
@@ -11,8 +12,11 @@ class ReservationCalendarTabScreen extends StatefulWidget {
 class _ReservationCalendarTabScreenState extends State<ReservationCalendarTabScreen> {
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Text("달력"),
+    return TableCalendar(
+      locale: 'ko_KR',
+      firstDay: DateTime(DateTime.now().year),
+      lastDay: DateTime(DateTime.now().year + 1),
+      focusedDay: DateTime.now(),
     );
   }
 }

--- a/lib/presentation/views/main/tabs/search/calendar/reservation_calendar_tab_screen.dart
+++ b/lib/presentation/views/main/tabs/search/calendar/reservation_calendar_tab_screen.dart
@@ -1,22 +1,234 @@
-
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reservation_app/presentation/utils/color_constants.dart';
+import 'package:reservation_app/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_bloc.dart';
+import 'package:reservation_app/presentation/views/main/tabs/search/calendar/utils/calendar_utils.dart';
 import 'package:table_calendar/table_calendar.dart';
 
 class ReservationCalendarTabScreen extends StatefulWidget {
   const ReservationCalendarTabScreen({Key? key}) : super(key: key);
 
   @override
-  State<ReservationCalendarTabScreen> createState() => _ReservationCalendarTabScreenState();
+  State<ReservationCalendarTabScreen> createState() =>
+      _ReservationCalendarTabScreenState();
 }
 
-class _ReservationCalendarTabScreenState extends State<ReservationCalendarTabScreen> {
+class _ReservationCalendarTabScreenState
+    extends State<ReservationCalendarTabScreen> {
+  late final ReservationCalendarTabBloc _reservationCalendarTabBloc;
+  late final ValueNotifier<List<Event>> _selectedEvents;
+
+  CalendarFormat _calendarFormat = CalendarFormat.month;
+  RangeSelectionMode _rangeSelectionMode = RangeSelectionMode.toggledOff;
+  DateTime _focusedDay = DateTime.now();
+
+  DateTime? _selectedDay;
+  DateTime? _rangeStart;
+  DateTime? _rangeEnd;
+
+  @override
+  void initState() {
+    super.initState();
+    _reservationCalendarTabBloc = BlocProvider.of<ReservationCalendarTabBloc>(
+      context,
+    );
+    _selectedDay = _focusedDay;
+    _selectedEvents = ValueNotifier(_getEventsForDay(_selectedDay!));
+
+    _reservationCalendarTabBloc.add(ReservationCalendarTabInitDataEvent());
+  }
+
+  List<Event> _getEventsForDay(DateTime day) {
+    return kEvents[day] ?? [];
+  }
+
+  List<Event> _getEventsForRange(DateTime start, DateTime end) {
+    // Implementation example
+    final days = daysInRange(start, end);
+
+    return [
+      for (final d in days) ..._getEventsForDay(d),
+    ];
+  }
+
+  void _onDaySelected(DateTime selectedDay, DateTime focusedDay) {
+    if (!isSameDay(_selectedDay, selectedDay)) {
+      setState(() {
+        _selectedDay = selectedDay;
+        _focusedDay = focusedDay;
+        _rangeStart = null; // Important to clean those
+        _rangeEnd = null;
+        _rangeSelectionMode = RangeSelectionMode.toggledOff;
+      });
+
+      _selectedEvents.value = _getEventsForDay(selectedDay);
+    }
+  }
+
+  void _onRangeSelected(DateTime? start, DateTime? end, DateTime focusedDay) {
+    setState(() {
+      _selectedDay = null;
+      _focusedDay = focusedDay;
+      _rangeStart = start;
+      _rangeEnd = end;
+      _rangeSelectionMode = RangeSelectionMode.toggledOn;
+    });
+
+    // `start` or `end` could be null
+    if (start != null && end != null) {
+      _selectedEvents.value = _getEventsForRange(start, end);
+    } else if (start != null) {
+      _selectedEvents.value = _getEventsForDay(start);
+    } else if (end != null) {
+      _selectedEvents.value = _getEventsForDay(end);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return TableCalendar(
-      locale: 'ko_KR',
-      firstDay: DateTime(DateTime.now().year),
-      lastDay: DateTime(DateTime.now().year + 1),
-      focusedDay: DateTime.now(),
+    return BlocConsumer<ReservationCalendarTabBloc,
+        ReservationCalendarTabState>(
+      bloc: _reservationCalendarTabBloc,
+      listenWhen: (previous, current) {
+        return previous != current;
+      },
+      listener: (context, state) {},
+      buildWhen: (previous, current) {
+        return previous != current;
+      },
+      builder: (context, state) {
+        return Column(
+          children: [
+            TableCalendar(
+              locale: 'ko_KR',
+              firstDay: DateTime(DateTime.now().year),
+              lastDay: DateTime(DateTime.now().year + 1),
+              focusedDay: _focusedDay,
+              selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
+              rangeStartDay: _rangeStart,
+              rangeEndDay: _rangeEnd,
+              calendarFormat: _calendarFormat,
+              rangeSelectionMode: _rangeSelectionMode,
+              eventLoader: _getEventsForDay,
+              startingDayOfWeek: StartingDayOfWeek.monday,
+              calendarStyle: CalendarStyle(
+                // Use `CalendarStyle` to customize the UI
+                outsideDaysVisible: false,
+                canMarkersOverflow: false,
+                markerMargin: const EdgeInsets.symmetric(horizontal: 0.3),
+                markerDecoration: const BoxDecoration(
+                  color: ColorsConstants.strokeColor,
+                  shape: BoxShape.circle,
+                ),
+                rangeHighlightColor: ColorsConstants.calendarSideColor,
+                rangeStartTextStyle: const TextStyle(
+                  color: ColorsConstants.background,
+                  fontSize: 16.0,
+                ),
+                rangeStartDecoration: const BoxDecoration(
+                  color: ColorsConstants.calendarPickerColor,
+                  shape: BoxShape.circle,
+                ),
+                rangeEndTextStyle: const TextStyle(
+                  color: ColorsConstants.background,
+                  fontSize: 16.0,
+                ),
+                rangeEndDecoration: const BoxDecoration(
+                  color: ColorsConstants.calendarPickerColor,
+                  shape: BoxShape.circle,
+                ),
+                todayTextStyle: const TextStyle(
+                  color: ColorsConstants.background,
+                  fontSize: 16.0,
+                ),
+                todayDecoration: const BoxDecoration(
+                  color: ColorsConstants.calendarCurrentColor,
+                  shape: BoxShape.circle,
+                ),
+                selectedTextStyle: const TextStyle(
+                  color: ColorsConstants.background,
+                  fontSize: 16.0,
+                ),
+                selectedDecoration: const BoxDecoration(
+                  color: ColorsConstants.calendarRangeColor,
+                  shape: BoxShape.circle,
+                ),
+                holidayTextStyle: const TextStyle(
+                  color: ColorsConstants.primary,
+                ),
+                holidayDecoration: const BoxDecoration(
+                  shape: BoxShape.circle,
+                ),
+              ),
+              onDaySelected: _onDaySelected,
+              onRangeSelected: _onRangeSelected,
+              onFormatChanged: (format) {
+                if (_calendarFormat != format) {
+                  setState(() {
+                    _calendarFormat = format;
+                  });
+                }
+              },
+              onPageChanged: (focusedDay) {
+                _focusedDay = focusedDay;
+              },
+              holidayPredicate: (day) {
+                // 매주 화요일 쉬는 날
+                return day.weekday == 2;
+              },
+              headerStyle: HeaderStyle(
+                titleCentered: true,
+                formatButtonVisible: false,
+                titleTextStyle: const TextStyle(
+                  fontSize: 20.0,
+                  color: ColorsConstants.strokeColor,
+                  fontWeight: FontWeight.bold,
+                ),
+                headerPadding: const EdgeInsets.symmetric(vertical: 4.0),
+                leftChevronIcon: const Icon(
+                  Icons.arrow_left_rounded,
+                  size: 40.0,
+                  color: ColorsConstants.strokeColor,
+                ),
+                rightChevronIcon: const Icon(
+                  Icons.arrow_right_rounded,
+                  size: 40.0,
+                  color: ColorsConstants.strokeColor,
+                ),
+              ),
+            ),
+            const SizedBox(height: 10.0),
+            Expanded(
+              child: ValueListenableBuilder<List<Event>>(
+                valueListenable: _selectedEvents,
+                builder: (context, value, _) {
+                  return ListView.builder(
+                    itemCount: value.length,
+                    itemBuilder: (context, index) {
+                      return Container(
+                        margin: EdgeInsets.only(
+                          left: 10,
+                          right: 10,
+                          top: index == 0 ? 10 : 5,
+                          bottom: index == value.length - 1 ? 10 : 5,
+                        ),
+                        decoration: BoxDecoration(
+                          border: Border.all(),
+                          borderRadius: BorderRadius.circular(12.0),
+                        ),
+                        child: ListTile(
+                          onTap: () => print('${value[index]}'),
+                          title: Text('${value[index]}'),
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/presentation/views/main/tabs/search/calendar/utils/calendar_utils.dart
+++ b/lib/presentation/views/main/tabs/search/calendar/utils/calendar_utils.dart
@@ -1,51 +1,7 @@
-import 'dart:collection';
-
-import 'package:equatable/equatable.dart';
-import 'package:table_calendar/table_calendar.dart';
-
-class Event extends Equatable {
-  final String title;
-
-  const Event({
-    required this.title,
-  });
-
-  @override
-  List<Object?> get props => [title];
-
-  @override
-  bool? get stringify => false;
-}
-
-final kEvents = LinkedHashMap<DateTime, List<Event>>(
-  equals: isSameDay,
-  hashCode: getHashCode,
-)..addAll(_kEventSource);
-
-final _kEventSource = Map.fromIterable(List.generate(50, (index) => index),
-    key: (item) => DateTime.utc(kFirstDay.year, kFirstDay.month, item * 5),
-    value: (item) => List.generate(
-        item % 4 + 1, (index) => Event(title: 'Event $item | ${index + 1}')))
-  ..addAll({
-    kToday: [
-      Event(title: 'Today\'s Event 1'),
-      Event(title: 'Today\'s Event 2'),
-    ],
-  });
-
-int getHashCode(DateTime key) {
-  return key.day * 1000000 + key.month * 10000 + key.year;
-}
-
-/// Returns a list of [DateTime] objects from [first] to [last], inclusive.
 List<DateTime> daysInRange(DateTime first, DateTime last) {
   final dayCount = last.difference(first).inDays + 1;
   return List.generate(
     dayCount,
-        (index) => DateTime.utc(first.year, first.month, first.day + index),
+    (index) => DateTime.utc(first.year, first.month, first.day + index),
   );
 }
-
-final kToday = DateTime.now();
-final kFirstDay = DateTime(kToday.year, kToday.month - 3, kToday.day);
-final kLastDay = DateTime(kToday.year, kToday.month + 3, kToday.day);

--- a/lib/presentation/views/main/tabs/search/calendar/utils/calendar_utils.dart
+++ b/lib/presentation/views/main/tabs/search/calendar/utils/calendar_utils.dart
@@ -1,0 +1,51 @@
+import 'dart:collection';
+
+import 'package:equatable/equatable.dart';
+import 'package:table_calendar/table_calendar.dart';
+
+class Event extends Equatable {
+  final String title;
+
+  const Event({
+    required this.title,
+  });
+
+  @override
+  List<Object?> get props => [title];
+
+  @override
+  bool? get stringify => false;
+}
+
+final kEvents = LinkedHashMap<DateTime, List<Event>>(
+  equals: isSameDay,
+  hashCode: getHashCode,
+)..addAll(_kEventSource);
+
+final _kEventSource = Map.fromIterable(List.generate(50, (index) => index),
+    key: (item) => DateTime.utc(kFirstDay.year, kFirstDay.month, item * 5),
+    value: (item) => List.generate(
+        item % 4 + 1, (index) => Event(title: 'Event $item | ${index + 1}')))
+  ..addAll({
+    kToday: [
+      Event(title: 'Today\'s Event 1'),
+      Event(title: 'Today\'s Event 2'),
+    ],
+  });
+
+int getHashCode(DateTime key) {
+  return key.day * 1000000 + key.month * 10000 + key.year;
+}
+
+/// Returns a list of [DateTime] objects from [first] to [last], inclusive.
+List<DateTime> daysInRange(DateTime first, DateTime last) {
+  final dayCount = last.difference(first).inDays + 1;
+  return List.generate(
+    dayCount,
+        (index) => DateTime.utc(first.year, first.month, first.day + index),
+  );
+}
+
+final kToday = DateTime.now();
+final kFirstDay = DateTime(kToday.year, kToday.month - 3, kToday.day);
+final kLastDay = DateTime(kToday.year, kToday.month + 3, kToday.day);

--- a/lib/presentation/views/main/tabs/search/calendar/widget/calendar_detail_item_widget.dart
+++ b/lib/presentation/views/main/tabs/search/calendar/widget/calendar_detail_item_widget.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:reservation_app/domain/model/reservation/reservation_range_section_model.dart';
+import 'package:reservation_app/presentation/utils/color_constants.dart';
+import 'package:reservation_app/presentation/utils/date_time_utils.dart';
+import 'package:reservation_app/presentation/views/common/bolder_text_widget.dart';
+import 'package:reservation_app/presentation/views/main/tabs/search/check/utils/check_utils.dart';
+
+class CalendarDetailItemWidget extends StatefulWidget {
+  final ReservationRangeSectionModel item;
+
+  const CalendarDetailItemWidget({
+    Key? key,
+    required this.item,
+  }) : super(key: key);
+
+  @override
+  State<CalendarDetailItemWidget> createState() =>
+      _CalendarDetailItemWidgetState();
+}
+
+class _CalendarDetailItemWidgetState extends State<CalendarDetailItemWidget> {
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      shrinkWrap: true,
+      physics: NeverScrollableScrollPhysics(),
+      itemCount: widget.item.list.length,
+      itemBuilder: (context, index) {
+        final item = widget.item.list[index];
+        final isAuthUser = widget.item.list[index].certificationNumber != null;
+
+        return Container(
+          padding: EdgeInsets.symmetric(vertical: 20),
+          margin: EdgeInsets.symmetric(horizontal: 20),
+          decoration: index == widget.item.list.length - 1 ? null : BoxDecoration(
+            border: Border(
+              bottom: BorderSide(
+                color: ColorsConstants.settingDivider,
+                width: 1.0,
+              ),
+            ),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Row(
+                children: [
+                  Container(
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      border: Border.all(
+                        color: isAuthUser
+                            ? ColorsConstants.strokeColor
+                            : ColorsConstants.primary,
+                        width: 2.0,
+                      ),
+                    ),
+                    alignment: Alignment.center,
+                    padding: EdgeInsets.all(10.0),
+                    child: Icon(
+                      isAuthUser ? Icons.check : Icons.close,
+                      color: isAuthUser
+                          ? ColorsConstants.strokeColor
+                          : ColorsConstants.primary,
+                    ),
+                  ),
+                  SizedBox(width: 15),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      BorderTextWidget(
+                        texts: [
+                          "예약자 : ",
+                          [
+                            (item.name),
+                            true
+                          ]
+                        ],
+                        normalFontSize: 12,
+                        bolderFontSize: 12,
+                        normalColors: ColorsConstants.divider,
+                        bolderColors: ColorsConstants.divider,
+                        bolderFontWeight: FontWeight.w600,
+                      ),
+                      BorderTextWidget(
+                        texts: [
+                          "예약 인원 : ",
+                          [
+                            (CheckUtils.makeReservationCount(
+                              item.reservationCount,
+                            )),
+                            true
+                          ]
+                        ],
+                        normalFontSize: 12,
+                        bolderFontSize: 12,
+                        normalColors: ColorsConstants.divider,
+                        bolderColors: ColorsConstants.divider,
+                        bolderFontWeight: FontWeight.w600,
+                      ),
+                      BorderTextWidget(
+                        texts: [
+                          "예약 시간 : ",
+                          [
+                            DateTimeUtils.stringToDateTime(
+                              item.reservationDateTime,
+                            ),
+                            true
+                          ]
+                        ],
+                        normalFontSize: 12,
+                        bolderFontSize: 12,
+                        normalColors: ColorsConstants.divider,
+                        bolderColors: ColorsConstants.divider,
+                        bolderFontWeight: FontWeight.w600,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/presentation/views/main/tabs/search/calendar/widget/calendar_empty_widget.dart
+++ b/lib/presentation/views/main/tabs/search/calendar/widget/calendar_empty_widget.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:lottie/lottie.dart';
+import 'package:reservation_app/presentation/utils/color_constants.dart';
+
+class CalendarEmptyWidget extends StatelessWidget {
+  final String message;
+  const CalendarEmptyWidget({
+    Key? key,
+    required this.message,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: EdgeInsets.only(top: 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [
+          Lottie.asset(
+            'assets/lottie/empty_animation.json',
+            animate: true,
+            width: 100,
+            height: 100,
+            repeat: false,
+          ),
+          Text(
+            message,
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+              color: ColorsConstants.guideText,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/views/main/tabs/search/calendar/widget/calendar_summary_list_widget.dart
+++ b/lib/presentation/views/main/tabs/search/calendar/widget/calendar_summary_list_widget.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:grouped_list/grouped_list.dart';
+import 'package:reservation_app/domain/model/reservation/reservation_target_date_model.dart';
+import 'package:reservation_app/presentation/utils/color_constants.dart';
+import 'package:reservation_app/presentation/utils/constants.dart';
+import 'package:reservation_app/presentation/utils/date_time_utils.dart';
+import 'package:reservation_app/presentation/views/common/network_error_widget.dart';
+import 'package:reservation_app/presentation/views/common/network_loading_widget.dart';
+import 'package:reservation_app/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_bloc.dart';
+import 'package:reservation_app/presentation/views/main/tabs/search/calendar/widget/calendar_empty_widget.dart';
+
+class CalendarSummaryListWidget extends StatefulWidget {
+  final DateTime selectedDate;
+  const CalendarSummaryListWidget({
+    Key? key,
+    required this.selectedDate,
+  }) : super(key: key);
+
+  @override
+  State<CalendarSummaryListWidget> createState() =>
+      _CalendarSummaryListWidgetState();
+}
+
+class _CalendarSummaryListWidgetState extends State<CalendarSummaryListWidget> {
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ReservationCalendarTabBloc, ReservationCalendarTabState>(
+        builder: (context, state) {
+      if (state.targetListStatus == TargetListStatus.loading) {
+        return NetworkLoadingWidget();
+      } else if (state.targetListStatus == TargetListStatus.error) {
+        return NetworkErrorWidget(
+          errorMessage: state.targetListErrorMsg ?? Constants.networkError,
+        );
+      } else if (state.targetListStatus == TargetListStatus.success) {
+        if (state.targetList.isEmpty) {
+          return CalendarEmptyWidget(message: "예약이 없습니다.");
+        }
+
+        return LayoutBuilder(
+          builder: (context, constraints) {
+            return ConstrainedBox(
+              constraints: BoxConstraints(
+                minHeight: constraints.maxHeight,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: [
+                  Container(
+                    constraints: const BoxConstraints.expand(height: 10.0),
+                  ),
+                  Row(
+                    children: [
+                      SizedBox(width: 10),
+                      Icon(Icons.date_range_outlined),
+                      SizedBox(width: 5),
+                      Text(
+                        "${DateTimeUtils.dateTimeToYearDateString(
+                          widget.selectedDate,
+                        )} 예약 정보",
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600,
+                          color: ColorsConstants.divider,
+                        ),
+                      ),
+                    ],
+                  ),
+                  Container(
+                    constraints: const BoxConstraints.expand(height: 5.0),
+                  ),
+                  Expanded(
+                    child: GroupedListView<ReservationTargetDateModel, String>(
+                      elements: state.targetList,
+                      padding: EdgeInsets.only(left: 15),
+                      groupBy: (reservation) => reservation.partTime,
+                      groupSeparatorBuilder: (groupByValue) => Padding(
+                        padding: const EdgeInsets.only(top: 10.0),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          children: [
+                            Container(
+                              padding: const EdgeInsets.all(1),
+                              child: Container(
+                                height: 20,
+                                width: 20,
+                                decoration: BoxDecoration(
+                                  shape: BoxShape.circle,
+                                  color: groupByValue == "PART_A"
+                                      ? ColorsConstants.partTimeA
+                                      : groupByValue == "PART_B"
+                                      ? ColorsConstants.partTimeB
+                                      : groupByValue == "PART_C"
+                                      ? ColorsConstants.partTimeC
+                                      : ColorsConstants.divider,
+                                ),
+                              ),
+                            ),
+                            SizedBox(width: 5),
+                            Text(
+                              groupByValue == "PART_A"
+                                  ? "PM 1:00 남은 좌석"
+                                  : groupByValue == "PART_B"
+                                      ? "PM 5:50 남은 좌석"
+                                      : groupByValue == "PART_C"
+                                          ? "PM 8:00 남은 좌석"
+                                          : groupByValue,
+                              style: TextStyle(
+                                fontWeight: FontWeight.w500,
+                                fontSize: 14,
+                                color: ColorsConstants.divider,
+                              ),
+                              textAlign: TextAlign.center,
+                            ),
+                          ],
+                        ),
+                      ),
+                      indexedItemBuilder: (context, reservation, index) {
+                        return Column(
+                          children: reservation.remainsSeatList.map((item) {
+                            final isSoldOut = item.seatCount == 0;
+
+                            return Padding(
+                              padding:
+                                  EdgeInsets.only(left: 8, top: 5, bottom: 5),
+                              child: Row(
+                                children: [
+                                  Text(
+                                    "└─ ${item.seatCategory}",
+                                    style: TextStyle(
+                                      fontWeight: FontWeight.w400,
+                                      fontSize: 13,
+                                      color: isSoldOut
+                                          ? ColorsConstants.primary
+                                          : ColorsConstants.divider,
+                                    ),
+                                  ),
+                                  Text(
+                                    " : ",
+                                    style: TextStyle(
+                                      fontWeight: FontWeight.w400,
+                                      fontSize: 13,
+                                      color: isSoldOut
+                                          ? ColorsConstants.primary
+                                          : ColorsConstants.divider,
+                                    ),
+                                  ),
+                                  Text(
+                                    '${isSoldOut ? '- 매진 -' : item.seatCount}',
+                                    style: TextStyle(
+                                      fontWeight: FontWeight.w400,
+                                      fontSize: 13,
+                                      color: isSoldOut
+                                          ? ColorsConstants.primary
+                                          : ColorsConstants.divider,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            );
+                          }).toList(),
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      } else {
+        return SizedBox.shrink();
+      }
+    });
+  }
+}

--- a/lib/presentation/views/main/tabs/search/check/bloc/reservation_check_bloc.dart
+++ b/lib/presentation/views/main/tabs/search/check/bloc/reservation_check_bloc.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:reservation_app/domain/model/base/data_state.dart';
@@ -104,7 +105,7 @@ class ReservationCheckBloc
 
     final response = await _getReservationFilterPageListUseCase.invoke(
       event.page,
-      5,
+      10,
       event.filterType,
     );
 
@@ -114,6 +115,8 @@ class ReservationCheckBloc
       if (result != null) {
         final list = List<ReservationFilterModel>.from(state.reservationList);
         list.addAll(result.reservationList);
+
+        debugPrint("result 👉 $result");
 
         emit(
           state.copyWith(

--- a/lib/presentation/views/main/tabs/search/check/reservation_check_tab_screen.dart
+++ b/lib/presentation/views/main/tabs/search/check/reservation_check_tab_screen.dart
@@ -202,6 +202,7 @@ class _ReservationCheckTabScreenState extends State<ReservationCheckTabScreen> {
       if (state.reservationList.isNotEmpty) {
         return SlidableAutoCloseBehavior(
           child: ListView.builder(
+            shrinkWrap: true,
             controller: _scrollController,
             itemCount: state.reservationList.length,
             itemBuilder: (context, index) {

--- a/lib/presentation/views/main/tabs/search/search_tab_screen.dart
+++ b/lib/presentation/views/main/tabs/search/search_tab_screen.dart
@@ -6,6 +6,7 @@ import 'package:reservation_app/presentation/utils/color_constants.dart';
 import 'package:reservation_app/presentation/utils/constants.dart';
 import 'package:reservation_app/presentation/utils/list_extensions.dart';
 import 'package:reservation_app/presentation/utils/snack_bar_utils.dart';
+import 'package:reservation_app/presentation/views/main/tabs/search/calendar/bloc/reservation_calendar_tab_bloc.dart';
 import 'package:reservation_app/presentation/views/main/tabs/search/calendar/reservation_calendar_tab_screen.dart';
 import 'package:reservation_app/presentation/views/main/tabs/search/chart/reservation_chart_tab_screen.dart';
 import 'package:reservation_app/presentation/views/main/tabs/search/check/bloc/reservation_check_bloc.dart';
@@ -49,6 +50,9 @@ class _SearchTabScreenState extends State<SearchTabScreen>
     return MultiBlocProvider(
       providers: [
         BlocProvider(
+          create: (context) => locator.get<ReservationCalendarTabBloc>(),
+        ),
+        BlocProvider(
           create: (context) => locator.get<ReservationCheckBloc>(),
         ),
       ],
@@ -56,6 +60,7 @@ class _SearchTabScreenState extends State<SearchTabScreen>
         length: Constants.searchTabCategoryList.length,
         initialIndex: 0,
         child: BlocSelector<UserInfoBloc, UserInfoState, MemberModel?>(
+          bloc: _userInfoBloc,
           selector: (state) {
             return state.memberModel;
           },
@@ -66,7 +71,9 @@ class _SearchTabScreenState extends State<SearchTabScreen>
                 bottom: TabBar(
                   onTap: (index) {
                     if (index > 0 && state == null) {
-                      SnackBarUtils.showCustomSnackBar(context, "관리자만 사용가능합니다.");
+                      SnackBarUtils.showCustomSnackBar(
+                          context, "관리자만 사용가능합니다.",
+                      );
                       return;
                     }
                   },

--- a/lib/presentation/views/main/tabs/setting/setting_tab_screen.dart
+++ b/lib/presentation/views/main/tabs/setting/setting_tab_screen.dart
@@ -179,7 +179,16 @@ class _SettingTabScreenState extends State<SettingTabScreen> {
                             message: "정말 로그아웃 하시겠습니까?",
                             enableCancelBtn: true,
                             onConfirmClick: () {
-                              _signBloc.add(SignOnSignOutClickEvent());
+                              final memberId =
+                                  _userInfoBloc.state.memberModel?.id;
+
+                              if (memberId != null) {
+                                _signBloc.add(
+                                  SignOnSignOutClickEvent(
+                                    memberId: memberId,
+                                  ),
+                                );
+                              }
                             },
                           );
                         },

--- a/lib/presentation/views/reservation/view/reservation_fourth_process_view.dart
+++ b/lib/presentation/views/reservation/view/reservation_fourth_process_view.dart
@@ -272,7 +272,7 @@ class _ReservationFourthProcessViewState
                         onChanged: (value) {
                           setState(() {
                             _isNameValidate = value.isNotEmpty &&
-                                value.length > 2 &&
+                                value.length >= 2 &&
                                 TextUtils.isNameValid(value);
 
                             if (_isNameValidate) {

--- a/lib/presentation/views/sign/bloc/sign_bloc.dart
+++ b/lib/presentation/views/sign/bloc/sign_bloc.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:reservation_app/di/prefs/shared_pref_module.dart';
 import 'package:reservation_app/domain/model/base/data_state.dart';
+import 'package:reservation_app/domain/model/sign/request/sign_out_request_model.dart';
 import 'package:reservation_app/domain/model/sign/sign_in_request_model.dart';
 import 'package:reservation_app/domain/usecase/sign/request_sign_in_use_case.dart';
 import 'package:reservation_app/domain/usecase/sign/request_sign_out_use_case.dart';
@@ -172,7 +173,11 @@ class SignBloc extends Bloc<SignEvent, SignState> {
   ) async {
     emit(state.copyWith(signOutStatus: SignOutState.loading));
 
-    final response = await _requestSignOutUseCase.invoke();
+    final response = await _requestSignOutUseCase.invoke(
+      SignOutRequestModel(
+        memberId: event.memberId,
+      ),
+    );
 
     if (response is DataSuccess<bool>) {
       final result = response.data ?? false;

--- a/lib/presentation/views/sign/bloc/sign_bloc.freezed.dart
+++ b/lib/presentation/views/sign/bloc/sign_bloc.freezed.dart
@@ -23,7 +23,7 @@ mixin _$SignEvent {
     required TResult Function() setIsEnablePush,
     required TResult Function() setIsSavedId,
     required TResult Function(String id, String password) onSignClick,
-    required TResult Function() onSignOutClick,
+    required TResult Function(int memberId) onSignOutClick,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -33,7 +33,7 @@ mixin _$SignEvent {
     TResult? Function()? setIsEnablePush,
     TResult? Function()? setIsSavedId,
     TResult? Function(String id, String password)? onSignClick,
-    TResult? Function()? onSignOutClick,
+    TResult? Function(int memberId)? onSignOutClick,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -43,7 +43,7 @@ mixin _$SignEvent {
     TResult Function()? setIsEnablePush,
     TResult Function()? setIsSavedId,
     TResult Function(String id, String password)? onSignClick,
-    TResult Function()? onSignOutClick,
+    TResult Function(int memberId)? onSignOutClick,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -146,7 +146,7 @@ class _$SignInitEvent with DiagnosticableTreeMixin implements SignInitEvent {
     required TResult Function() setIsEnablePush,
     required TResult Function() setIsSavedId,
     required TResult Function(String id, String password) onSignClick,
-    required TResult Function() onSignOutClick,
+    required TResult Function(int memberId) onSignOutClick,
   }) {
     return init();
   }
@@ -159,7 +159,7 @@ class _$SignInitEvent with DiagnosticableTreeMixin implements SignInitEvent {
     TResult? Function()? setIsEnablePush,
     TResult? Function()? setIsSavedId,
     TResult? Function(String id, String password)? onSignClick,
-    TResult? Function()? onSignOutClick,
+    TResult? Function(int memberId)? onSignOutClick,
   }) {
     return init?.call();
   }
@@ -172,7 +172,7 @@ class _$SignInitEvent with DiagnosticableTreeMixin implements SignInitEvent {
     TResult Function()? setIsEnablePush,
     TResult Function()? setIsSavedId,
     TResult Function(String id, String password)? onSignClick,
-    TResult Function()? onSignOutClick,
+    TResult Function(int memberId)? onSignOutClick,
     required TResult orElse(),
   }) {
     if (init != null) {
@@ -280,7 +280,7 @@ class _$SignIsAutoLoginEvent
     required TResult Function() setIsEnablePush,
     required TResult Function() setIsSavedId,
     required TResult Function(String id, String password) onSignClick,
-    required TResult Function() onSignOutClick,
+    required TResult Function(int memberId) onSignOutClick,
   }) {
     return setIsAutoLogin();
   }
@@ -293,7 +293,7 @@ class _$SignIsAutoLoginEvent
     TResult? Function()? setIsEnablePush,
     TResult? Function()? setIsSavedId,
     TResult? Function(String id, String password)? onSignClick,
-    TResult? Function()? onSignOutClick,
+    TResult? Function(int memberId)? onSignOutClick,
   }) {
     return setIsAutoLogin?.call();
   }
@@ -306,7 +306,7 @@ class _$SignIsAutoLoginEvent
     TResult Function()? setIsEnablePush,
     TResult Function()? setIsSavedId,
     TResult Function(String id, String password)? onSignClick,
-    TResult Function()? onSignOutClick,
+    TResult Function(int memberId)? onSignOutClick,
     required TResult orElse(),
   }) {
     if (setIsAutoLogin != null) {
@@ -414,7 +414,7 @@ class _$SignIsEnablePushEvent
     required TResult Function() setIsEnablePush,
     required TResult Function() setIsSavedId,
     required TResult Function(String id, String password) onSignClick,
-    required TResult Function() onSignOutClick,
+    required TResult Function(int memberId) onSignOutClick,
   }) {
     return setIsEnablePush();
   }
@@ -427,7 +427,7 @@ class _$SignIsEnablePushEvent
     TResult? Function()? setIsEnablePush,
     TResult? Function()? setIsSavedId,
     TResult? Function(String id, String password)? onSignClick,
-    TResult? Function()? onSignOutClick,
+    TResult? Function(int memberId)? onSignOutClick,
   }) {
     return setIsEnablePush?.call();
   }
@@ -440,7 +440,7 @@ class _$SignIsEnablePushEvent
     TResult Function()? setIsEnablePush,
     TResult Function()? setIsSavedId,
     TResult Function(String id, String password)? onSignClick,
-    TResult Function()? onSignOutClick,
+    TResult Function(int memberId)? onSignOutClick,
     required TResult orElse(),
   }) {
     if (setIsEnablePush != null) {
@@ -548,7 +548,7 @@ class _$SignIsSavedIdEvent
     required TResult Function() setIsEnablePush,
     required TResult Function() setIsSavedId,
     required TResult Function(String id, String password) onSignClick,
-    required TResult Function() onSignOutClick,
+    required TResult Function(int memberId) onSignOutClick,
   }) {
     return setIsSavedId();
   }
@@ -561,7 +561,7 @@ class _$SignIsSavedIdEvent
     TResult? Function()? setIsEnablePush,
     TResult? Function()? setIsSavedId,
     TResult? Function(String id, String password)? onSignClick,
-    TResult? Function()? onSignOutClick,
+    TResult? Function(int memberId)? onSignOutClick,
   }) {
     return setIsSavedId?.call();
   }
@@ -574,7 +574,7 @@ class _$SignIsSavedIdEvent
     TResult Function()? setIsEnablePush,
     TResult Function()? setIsSavedId,
     TResult Function(String id, String password)? onSignClick,
-    TResult Function()? onSignOutClick,
+    TResult Function(int memberId)? onSignOutClick,
     required TResult orElse(),
   }) {
     if (setIsSavedId != null) {
@@ -721,7 +721,7 @@ class _$SignOnSignInClickEvent
     required TResult Function() setIsEnablePush,
     required TResult Function() setIsSavedId,
     required TResult Function(String id, String password) onSignClick,
-    required TResult Function() onSignOutClick,
+    required TResult Function(int memberId) onSignOutClick,
   }) {
     return onSignClick(id, password);
   }
@@ -734,7 +734,7 @@ class _$SignOnSignInClickEvent
     TResult? Function()? setIsEnablePush,
     TResult? Function()? setIsSavedId,
     TResult? Function(String id, String password)? onSignClick,
-    TResult? Function()? onSignOutClick,
+    TResult? Function(int memberId)? onSignOutClick,
   }) {
     return onSignClick?.call(id, password);
   }
@@ -747,7 +747,7 @@ class _$SignOnSignInClickEvent
     TResult Function()? setIsEnablePush,
     TResult Function()? setIsSavedId,
     TResult Function(String id, String password)? onSignClick,
-    TResult Function()? onSignOutClick,
+    TResult Function(int memberId)? onSignOutClick,
     required TResult orElse(),
   }) {
     if (onSignClick != null) {
@@ -817,6 +817,8 @@ abstract class _$$SignOnSignOutClickEventCopyWith<$Res> {
   factory _$$SignOnSignOutClickEventCopyWith(_$SignOnSignOutClickEvent value,
           $Res Function(_$SignOnSignOutClickEvent) then) =
       __$$SignOnSignOutClickEventCopyWithImpl<$Res>;
+  @useResult
+  $Res call({int memberId});
 }
 
 /// @nodoc
@@ -826,6 +828,19 @@ class __$$SignOnSignOutClickEventCopyWithImpl<$Res>
   __$$SignOnSignOutClickEventCopyWithImpl(_$SignOnSignOutClickEvent _value,
       $Res Function(_$SignOnSignOutClickEvent) _then)
       : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? memberId = null,
+  }) {
+    return _then(_$SignOnSignOutClickEvent(
+      memberId: null == memberId
+          ? _value.memberId
+          : memberId // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
 }
 
 /// @nodoc
@@ -833,28 +848,42 @@ class __$$SignOnSignOutClickEventCopyWithImpl<$Res>
 class _$SignOnSignOutClickEvent
     with DiagnosticableTreeMixin
     implements SignOnSignOutClickEvent {
-  const _$SignOnSignOutClickEvent();
+  const _$SignOnSignOutClickEvent({required this.memberId});
+
+  @override
+  final int memberId;
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'SignEvent.onSignOutClick()';
+    return 'SignEvent.onSignOutClick(memberId: $memberId)';
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty('type', 'SignEvent.onSignOutClick'));
+    properties
+      ..add(DiagnosticsProperty('type', 'SignEvent.onSignOutClick'))
+      ..add(DiagnosticsProperty('memberId', memberId));
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SignOnSignOutClickEvent);
+            other is _$SignOnSignOutClickEvent &&
+            (identical(other.memberId, memberId) ||
+                other.memberId == memberId));
   }
 
   @override
-  int get hashCode => runtimeType.hashCode;
+  int get hashCode => Object.hash(runtimeType, memberId);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SignOnSignOutClickEventCopyWith<_$SignOnSignOutClickEvent> get copyWith =>
+      __$$SignOnSignOutClickEventCopyWithImpl<_$SignOnSignOutClickEvent>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -864,9 +893,9 @@ class _$SignOnSignOutClickEvent
     required TResult Function() setIsEnablePush,
     required TResult Function() setIsSavedId,
     required TResult Function(String id, String password) onSignClick,
-    required TResult Function() onSignOutClick,
+    required TResult Function(int memberId) onSignOutClick,
   }) {
-    return onSignOutClick();
+    return onSignOutClick(memberId);
   }
 
   @override
@@ -877,9 +906,9 @@ class _$SignOnSignOutClickEvent
     TResult? Function()? setIsEnablePush,
     TResult? Function()? setIsSavedId,
     TResult? Function(String id, String password)? onSignClick,
-    TResult? Function()? onSignOutClick,
+    TResult? Function(int memberId)? onSignOutClick,
   }) {
-    return onSignOutClick?.call();
+    return onSignOutClick?.call(memberId);
   }
 
   @override
@@ -890,11 +919,11 @@ class _$SignOnSignOutClickEvent
     TResult Function()? setIsEnablePush,
     TResult Function()? setIsSavedId,
     TResult Function(String id, String password)? onSignClick,
-    TResult Function()? onSignOutClick,
+    TResult Function(int memberId)? onSignOutClick,
     required TResult orElse(),
   }) {
     if (onSignOutClick != null) {
-      return onSignOutClick();
+      return onSignOutClick(memberId);
     }
     return orElse();
   }
@@ -944,7 +973,13 @@ class _$SignOnSignOutClickEvent
 }
 
 abstract class SignOnSignOutClickEvent implements SignEvent {
-  const factory SignOnSignOutClickEvent() = _$SignOnSignOutClickEvent;
+  const factory SignOnSignOutClickEvent({required final int memberId}) =
+      _$SignOnSignOutClickEvent;
+
+  int get memberId;
+  @JsonKey(ignore: true)
+  _$$SignOnSignOutClickEventCopyWith<_$SignOnSignOutClickEvent> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc

--- a/lib/presentation/views/sign/bloc/sign_event.dart
+++ b/lib/presentation/views/sign/bloc/sign_event.dart
@@ -15,5 +15,7 @@ class SignEvent with _$SignEvent {
     required String password,
   }) = SignOnSignInClickEvent;
 
-  const factory SignEvent.onSignOutClick() = SignOnSignOutClickEvent;
+  const factory SignEvent.onSignOutClick({
+    required int memberId,
+  }) = SignOnSignOutClickEvent;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -989,6 +989,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  simple_gesture_detector:
+    dependency: transitive
+    description:
+      name: simple_gesture_detector
+      sha256: "86d08f85f1f58583b7b4b941d989f48ea6ce08c1724a1d10954a277c2ec36592"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -1106,6 +1114,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  table_calendar:
+    dependency: "direct main"
+    description:
+      name: table_calendar
+      sha256: "1e3521a3e6d3fc7f645a58b135ab663d458ab12504f1ea7f9b4b81d47086c478"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.9"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,6 +75,8 @@ dependencies:
   pull_to_refresh: ^2.0.0
   # List Swipe
   flutter_slidable: ^3.0.0
+  # 달력
+  table_calendar: ^3.0.9
 
   flutter_localizations:
     sdk: flutter


### PR DESCRIPTION
## 🌸 예약 달력 기능 구현
- `table_calendar` 라이브러리를 사용하여 달력을 구현하고 각 날짜에 예약된 예약 List 들을 보여주는 기능 추가

- **_요약 보기_** 및 **_상세 보기_** 기능을 제공
  > - 요약 보기 👉 해당 날짜에 남은 좌석을 보여줌 
  > - 상세 보기 👉 해당 날짜에 예약한 유저를 보여줌

- 범위 선택 👉 범위 선택 시 해당 범위안에 있는 예약 정보를 List로 보여줌
  > 범위 선택의 경우 **_요약 보기_** 사용 불가

### 🌹 pubspec.lock
- [table_calendar](https://github.com/aleksanderwozniak/table_calendar) 👉 달력 구현을 위해 추가

``` yaml
table_calendar: ^3.0.9
```